### PR TITLE
Fix manual npm publish workflow handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,17 @@
 name: Publish aminet
 
 on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to publish from"
+        required: true
+        default: "main"
+        type: string
+      tag_name:
+        description: "Optional release tag (example: v0.1.2)"
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -19,23 +30,45 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Verify tag matches package version
+      - name: Resolve release context
+        id: release_context
         shell: bash
         run: |
           PACKAGE_VERSION=$(node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); process.stdout.write(pkg.version)")
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_VERSION)." >&2
-            exit 1
+          TAG_NAME=""
+
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_NAME="${GITHUB_REF_NAME}"
+          elif [ -n "${INPUT_TAG_NAME}" ]; then
+            TAG_NAME="${INPUT_TAG_NAME}"
           fi
+
+          RELEASE_VERSION="$PACKAGE_VERSION"
+          if [ -n "$TAG_NAME" ]; then
+            RELEASE_VERSION="${TAG_NAME#v}"
+            if [ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]; then
+              echo "Tag version ($RELEASE_VERSION) does not match package.json version ($PACKAGE_VERSION)." >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "package_version=$PACKAGE_VERSION"
+            echo "release_version=$RELEASE_VERSION"
+            echo "tag_name=$TAG_NAME"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -47,15 +80,20 @@ jobs:
           pnpm build
 
       - name: Build release notes body
+        if: steps.release_context.outputs.tag_name != ''
         id: release_notes
         uses: actions/github-script@v7
+        env:
+          RELEASE_VERSION: ${{ steps.release_context.outputs.release_version }}
+          RELEASE_TAG_NAME: ${{ steps.release_context.outputs.tag_name }}
         with:
           script: |
-            const version = process.env.GITHUB_REF_NAME.replace(/^v/, "");
+            const version = process.env.RELEASE_VERSION;
+            const tagName = process.env.RELEASE_TAG_NAME;
             const generated = await github.rest.repos.generateReleaseNotes({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: context.ref.replace("refs/tags/", ""),
+              tag_name: tagName,
               target_commitish: context.sha,
             });
 
@@ -89,9 +127,12 @@ jobs:
             fs.writeFileSync("release-notes.md", body);
 
       - name: Publish to npm
-        run: npm publish --provenance
+        run: npm publish --provenance --access public
 
       - name: Create GitHub release
+        if: steps.release_context.outputs.tag_name != ''
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release_context.outputs.tag_name }}
+          target_commitish: ${{ github.sha }}
           body_path: release-notes.md

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ The intended release flow is tag-driven with npm trusted publishing.
 3. Create and push a `v<version>` tag
 4. GitHub Actions publishes the matching npm package and creates a GitHub Release
 
+You can also run the publish workflow manually with `workflow_dispatch` against a branch or tag. When you provide `tag_name`, it must still match `package.json`.
+
 One-time prerequisite: configure npm trusted publishing for `gorira-tatsu/aminet` and the publish workflow in npm package settings.
 
 ## Distribution

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,16 @@
    - install examples
    - action usage example
 
+## Manual publish fallback
+
+- The `Publish aminet` workflow can also be started with `workflow_dispatch`.
+- Set `ref` to the branch or tag you want to publish from.
+- Set `tag_name` only when you also want a GitHub Release. `tag_name` must match `package.json`.
+- Manual branch publishes skip GitHub Release creation unless `tag_name` is provided.
+
 ## Notes
 
 - npmjs.org is the canonical registry
 - Publishing uses npm trusted publishing with GitHub OIDC
+- npm trusted publisher configuration in npm package settings must allow this repository workflow
 - The release workflow expects the git tag version to exactly match `package.json`


### PR DESCRIPTION
## Summary
- add workflow_dispatch inputs so publish can run from a branch or tag
- keep tag/version verification for tagged releases while allowing manual branch publishes
- update publish docs and use Node 24 with `npm publish --provenance --access public`

## Context
The existing publish workflow only triggered on `v*` tag pushes and the recent npm publish failure showed we need a safer manual fallback while keeping the tagged release path intact.

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "ok"'
