### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aminet",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "CLI and GitHub Action for npm supply chain security reviews",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump `package.json` version from `0.1.1` to `0.1.3`
- align the next release tag with the workflow version guard

## Context
`v0.1.2` already exists while `package.json` was still `0.1.1`, so the publish workflow correctly rejected the release. This PR prepares the next valid release candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.1.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->