### PR TITLE
fix: upgrade actions/setup-node from v4 to v5

### DIFF
--- a/.github/workflows/ami-review.yml
+++ b/.github/workflows/ami-review.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: "20"
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/setup-node` from v4 to v5 in `action.yml` and `ami-review.yml`
- v5 uses Node.js 24 runtime, resolving the GitHub Actions deprecation warning for Node.js 20

Closes #6

## Test plan
- [ ] Run a workflow that uses the action and verify no deprecation warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)