### PR TITLE
test: add test infrastructure and improve test quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "start": "node ./dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:integration": "INTEGRATION_TEST=1 vitest run",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/test/core/license/checker.test.ts
+++ b/test/core/license/checker.test.ts
@@ -1,50 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { extractLicense } from "../../../src/core/license/checker.js";
-import { classifyLicense } from "../../../src/core/license/spdx.js";
 import type { NpmVersionInfo } from "../../../src/core/registry/types.js";
-
-describe("classifyLicense", () => {
-  test("classifies permissive licenses", () => {
-    expect(classifyLicense("MIT")).toBe("permissive");
-    expect(classifyLicense("ISC")).toBe("permissive");
-    expect(classifyLicense("Apache-2.0")).toBe("permissive");
-    expect(classifyLicense("BSD-2-Clause")).toBe("permissive");
-    expect(classifyLicense("BSD-3-Clause")).toBe("permissive");
-  });
-
-  test("classifies copyleft licenses", () => {
-    expect(classifyLicense("GPL-2.0")).toBe("copyleft");
-    expect(classifyLicense("GPL-3.0")).toBe("copyleft");
-    expect(classifyLicense("AGPL-3.0")).toBe("copyleft");
-    expect(classifyLicense("GPL-3.0-only")).toBe("copyleft");
-  });
-
-  test("classifies weak-copyleft licenses", () => {
-    expect(classifyLicense("LGPL-2.1")).toBe("weak-copyleft");
-    expect(classifyLicense("MPL-2.0")).toBe("weak-copyleft");
-    expect(classifyLicense("EPL-2.0")).toBe("weak-copyleft");
-  });
-
-  test("returns unknown for unrecognized licenses", () => {
-    expect(classifyLicense("WTFPL")).toBe("unknown");
-    expect(classifyLicense("Custom")).toBe("unknown");
-  });
-
-  test("handles SPDX OR expressions (most permissive wins)", () => {
-    expect(classifyLicense("MIT OR GPL-3.0")).toBe("permissive");
-    expect(classifyLicense("GPL-3.0 OR LGPL-2.1")).toBe("weak-copyleft");
-  });
-
-  test("handles SPDX AND expressions (most restrictive wins)", () => {
-    expect(classifyLicense("MIT AND GPL-3.0")).toBe("copyleft");
-    expect(classifyLicense("MIT AND MPL-2.0")).toBe("weak-copyleft");
-  });
-
-  test("respects parentheses when classifying nested SPDX expressions", () => {
-    expect(classifyLicense("MIT OR (GPL-3.0 AND LGPL-2.1)")).toBe("permissive");
-    expect(classifyLicense("(MIT OR LGPL-2.1) AND GPL-3.0")).toBe("copyleft");
-  });
-});
 
 describe("extractLicense", () => {
   test("extracts string license", () => {

--- a/test/core/report/builder.test.ts
+++ b/test/core/report/builder.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "vitest";
+import type { DependencyGraph } from "../../../src/core/graph/types.js";
+import { buildReport } from "../../../src/core/report/builder.js";
+import type { VulnerabilityResult } from "../../../src/core/vulnerability/types.js";
+
+function makeGraph(nodes: Parameters<typeof Map<string, any>>[0][]): DependencyGraph {
+  const nodesMap = new Map(
+    nodes.map(([id, data]) => [
+      id as string,
+      {
+        id: id as string,
+        name: (data as any).name ?? (id as string).split("@")[0],
+        version: (data as any).version ?? (id as string).split("@")[1],
+        license: (data as any).license ?? "MIT",
+        licenseCategory: (data as any).licenseCategory ?? "permissive",
+        depth: (data as any).depth ?? 0,
+        parents: new Set<string>(),
+        dependencies: new Map<string, string>(),
+      },
+    ]),
+  );
+  return { root: nodes[0][0] as string, nodes: nodesMap, edges: [] };
+}
+
+describe("buildReport", () => {
+  test("builds report from graph with no vulnerabilities", () => {
+    const graph = makeGraph([
+      ["root@1.0.0", { depth: 0 }],
+      ["dep-a@2.0.0", { depth: 1 }],
+    ]);
+
+    const report = buildReport(graph, []);
+
+    expect(report.root).toBe("root@1.0.0");
+    expect(report.totalPackages).toBe(2);
+    expect(report.entries).toHaveLength(2);
+    expect(report.summary.vulnerabilityCount).toBe(0);
+    expect(report.summary.licenseCounts.permissive).toBe(2);
+  });
+
+  test("counts vulnerability severities correctly", () => {
+    const graph = makeGraph([["pkg@1.0.0", { depth: 0 }]]);
+
+    const vulns: VulnerabilityResult[] = [
+      {
+        packageId: "pkg@1.0.0",
+        name: "pkg",
+        version: "1.0.0",
+        vulnerabilities: [
+          {
+            id: "GHSA-1",
+            summary: "Critical vuln",
+            severity: [{ type: "CVSS_V3", score: "9.5" }],
+          },
+          {
+            id: "GHSA-2",
+            summary: "High vuln",
+            severity: [{ type: "CVSS_V3", score: "7.5" }],
+          },
+          {
+            id: "GHSA-3",
+            summary: "Medium vuln",
+            severity: [{ type: "CVSS_V3", score: "5.0" }],
+          },
+          {
+            id: "GHSA-4",
+            summary: "Low vuln",
+            severity: [{ type: "CVSS_V3", score: "2.0" }],
+          },
+        ] as any,
+      },
+    ];
+
+    const report = buildReport(graph, vulns);
+
+    expect(report.summary.vulnerabilityCount).toBe(4);
+    expect(report.summary.criticalCount).toBe(1);
+    expect(report.summary.highCount).toBe(1);
+    expect(report.summary.mediumCount).toBe(1);
+    expect(report.summary.lowCount).toBe(1);
+  });
+
+  test("counts license categories correctly", () => {
+    const graph = makeGraph([
+      ["root@1.0.0", { depth: 0, license: "MIT", licenseCategory: "permissive" }],
+      ["gpl-pkg@1.0.0", { depth: 1, license: "GPL-3.0", licenseCategory: "copyleft" }],
+      ["lgpl-pkg@1.0.0", { depth: 1, license: "LGPL-2.1", licenseCategory: "weak-copyleft" }],
+      ["unknown-pkg@1.0.0", { depth: 1, license: null, licenseCategory: "unknown" }],
+    ]);
+
+    const report = buildReport(graph, []);
+
+    expect(report.summary.licenseCounts.permissive).toBe(1);
+    expect(report.summary.licenseCounts.copyleft).toBe(1);
+    expect(report.summary.licenseCounts["weak-copyleft"]).toBe(1);
+    expect(report.summary.licenseCounts.unknown).toBe(1);
+  });
+
+  test("sorts entries by depth then name", () => {
+    const graph = makeGraph([
+      ["root@1.0.0", { depth: 0 }],
+      ["zebra@1.0.0", { depth: 1 }],
+      ["alpha@1.0.0", { depth: 1 }],
+      ["deep@1.0.0", { depth: 2 }],
+    ]);
+
+    const report = buildReport(graph, []);
+
+    expect(report.entries.map((e) => e.id)).toEqual([
+      "root@1.0.0",
+      "alpha@1.0.0",
+      "zebra@1.0.0",
+      "deep@1.0.0",
+    ]);
+  });
+
+  test("handles empty graph", () => {
+    const graph: DependencyGraph = {
+      root: "empty@0.0.0",
+      nodes: new Map(),
+      edges: [],
+    };
+
+    const report = buildReport(graph, []);
+
+    expect(report.totalPackages).toBe(0);
+    expect(report.entries).toHaveLength(0);
+    expect(report.summary.vulnerabilityCount).toBe(0);
+  });
+
+  test("attaches optional data from options", () => {
+    const graph = makeGraph([["pkg@1.0.0", { depth: 0 }]]);
+
+    const report = buildReport(graph, [], {
+      securitySummary: {
+        criticalCount: 1,
+        highCount: 0,
+        mediumCount: 0,
+        lowCount: 0,
+        infoCount: 0,
+      },
+    });
+
+    expect(report.securitySummary).toBeDefined();
+    expect(report.securitySummary!.criticalCount).toBe(1);
+  });
+
+  test("uses database_specific severity as fallback", () => {
+    const graph = makeGraph([["pkg@1.0.0", { depth: 0 }]]);
+
+    const vulns: VulnerabilityResult[] = [
+      {
+        packageId: "pkg@1.0.0",
+        name: "pkg",
+        version: "1.0.0",
+        vulnerabilities: [
+          {
+            id: "GHSA-5",
+            summary: "DB severity",
+            database_specific: { severity: "high" },
+          },
+        ] as any,
+      },
+    ];
+
+    const report = buildReport(graph, vulns);
+    expect(report.entries[0].vulnerabilities[0].severity).toBe("HIGH");
+  });
+});

--- a/test/core/store/hash.test.ts
+++ b/test/core/store/hash.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, test } from "vitest";
 import { packageHash, packumentHash } from "../../../src/core/store/hash.js";
 
 describe("packageHash", () => {
-  test("produces deterministic output", () => {
-    const h1 = packageHash("npm", "express", "4.21.2");
-    const h2 = packageHash("npm", "express", "4.21.2");
-    expect(h1).toBe(h2);
+  test("produces expected hash for known input", () => {
+    expect(packageHash("npm", "express", "4.21.2")).toBe("705b7eb68a46ed181bba302c3ba5f348");
   });
 
   test("produces 32-character hex string", () => {
@@ -34,10 +32,8 @@ describe("packageHash", () => {
 });
 
 describe("packumentHash", () => {
-  test("produces deterministic output", () => {
-    const h1 = packumentHash("npm", "express");
-    const h2 = packumentHash("npm", "express");
-    expect(h1).toBe(h2);
+  test("produces expected hash for known input", () => {
+    expect(packumentHash("npm", "express")).toBe("1db97c492987c147581a662585d04220");
   });
 
   test("differs from packageHash", () => {

--- a/test/core/vulnerability/scanner.test.ts
+++ b/test/core/vulnerability/scanner.test.ts
@@ -1,71 +1,112 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { DependencyGraph } from "../../../src/core/graph/types.js";
 
-describe("vulnerability scanner", () => {
-  test("creates correct batch query structure", () => {
-    const packages = [
-      { name: "lodash", version: "4.17.20" },
-      { name: "express", version: "4.17.1" },
-    ];
+// Mock network-calling modules
+vi.mock("../../../src/core/vulnerability/osv-client.js", () => ({
+  queryBatchChunked: vi.fn(),
+  queryVulnDetails: vi.fn(),
+}));
 
-    const request = {
-      queries: packages.map((pkg) => ({
-        package: {
-          name: pkg.name,
-          version: pkg.version,
-          ecosystem: "npm",
-        },
-      })),
-    };
+vi.mock("../../../src/core/store/vulnerability-store.js", () => ({
+  getCachedVulnerabilities: vi.fn().mockReturnValue(null),
+  cacheVulnerabilities: vi.fn(),
+  cacheVulnerabilityBatch: vi.fn(),
+}));
 
-    expect(request.queries).toHaveLength(2);
-    expect(request.queries[0].package.ecosystem).toBe("npm");
-    expect(request.queries[0].package.name).toBe("lodash");
-    expect(request.queries[0].package.version).toBe("4.17.20");
+import { scanVulnerabilities } from "../../../src/core/vulnerability/scanner.js";
+
+function makeGraph(packages: Array<{ name: string; version: string }>): DependencyGraph {
+  const nodes = new Map(
+    packages.map((pkg) => [
+      `${pkg.name}@${pkg.version}`,
+      {
+        id: `${pkg.name}@${pkg.version}`,
+        name: pkg.name,
+        version: pkg.version,
+        license: "MIT",
+        licenseCategory: "permissive" as const,
+        depth: 0,
+        parents: new Set<string>(),
+        dependencies: new Map<string, string>(),
+      },
+    ]),
+  );
+  const root = packages.length > 0 ? `${packages[0].name}@${packages[0].version}` : "root@0.0.0";
+  return { root, nodes, edges: [] };
+}
+
+describe("scanVulnerabilities", () => {
+  test("returns empty array for empty graph", async () => {
+    const result = await scanVulnerabilities(makeGraph([]), 5, false);
+    expect(result).toEqual([]);
   });
 
-  test("filters packages with no vulnerabilities", () => {
-    const batchResults = {
-      results: [
-        { vulns: [{ id: "GHSA-1234", modified: "2024-01-01" }] },
-        {},
-        { vulns: [] },
-        { vulns: [{ id: "GHSA-5678", modified: "2024-02-01" }] },
-      ],
-    };
+  test("returns vulnerabilities when OSV reports hits", async () => {
+    const { queryBatchChunked, queryVulnDetails } = await import(
+      "../../../src/core/vulnerability/osv-client.js"
+    );
 
-    const packages = [
-      { name: "lodash", version: "4.17.20" },
-      { name: "express", version: "4.21.2" },
-      { name: "chalk", version: "5.3.0" },
-      { name: "qs", version: "6.5.2" },
-    ];
+    (queryBatchChunked as any).mockResolvedValueOnce({
+      results: [{ vulns: [{ id: "GHSA-1" }] }],
+    });
+    (queryVulnDetails as any).mockResolvedValueOnce([
+      { id: "GHSA-1", summary: "Test vuln", severity: [{ type: "CVSS_V3", score: "7.5" }] },
+    ]);
 
-    const vulnerablePackages: typeof packages = [];
-    for (let i = 0; i < packages.length; i++) {
-      const result = batchResults.results[i];
-      if (result?.vulns && result.vulns.length > 0) {
-        vulnerablePackages.push(packages[i]);
-      }
-    }
+    const results = await scanVulnerabilities(
+      makeGraph([{ name: "express", version: "4.17.0" }]),
+      5,
+      false,
+    );
 
-    expect(vulnerablePackages).toHaveLength(2);
-    expect(vulnerablePackages[0].name).toBe("lodash");
-    expect(vulnerablePackages[1].name).toBe("qs");
+    expect(results).toHaveLength(1);
+    expect(results[0].packageId).toBe("express@4.17.0");
+    expect(results[0].vulnerabilities[0].id).toBe("GHSA-1");
   });
 
-  test("handles empty graph", () => {
-    const graph: DependencyGraph = {
-      root: "empty@1.0.0",
-      nodes: new Map(),
-      edges: [],
-    };
+  test("returns empty when batch reports no vulns", async () => {
+    const { queryBatchChunked } = await import("../../../src/core/vulnerability/osv-client.js");
 
-    const packages = Array.from(graph.nodes.values()).map((node) => ({
-      name: node.name,
-      version: node.version,
-    }));
+    (queryBatchChunked as any).mockResolvedValueOnce({
+      results: [{ vulns: [] }],
+    });
 
-    expect(packages).toHaveLength(0);
+    const results = await scanVulnerabilities(
+      makeGraph([{ name: "safe-pkg", version: "1.0.0" }]),
+      5,
+      false,
+    );
+    expect(results).toEqual([]);
+  });
+
+  test("separates clean and vulnerable packages", async () => {
+    const { queryBatchChunked, queryVulnDetails } = await import(
+      "../../../src/core/vulnerability/osv-client.js"
+    );
+
+    (queryBatchChunked as any).mockResolvedValueOnce({
+      results: [{ vulns: [{ id: "GHSA-1" }] }, { vulns: [] }, { vulns: [{ id: "GHSA-2" }] }],
+    });
+
+    (queryVulnDetails as any).mockImplementation(async (name: string) => {
+      if (name === "vuln-a") return [{ id: "GHSA-1", summary: "A vuln" }];
+      return [{ id: "GHSA-2", summary: "C vuln" }];
+    });
+
+    const results = await scanVulnerabilities(
+      makeGraph([
+        { name: "vuln-a", version: "1.0.0" },
+        { name: "safe-b", version: "1.0.0" },
+        { name: "vuln-c", version: "1.0.0" },
+      ]),
+      5,
+      false,
+    );
+
+    expect(results).toHaveLength(2);
+    const names = results.map((r) => r.name);
+    expect(names).toContain("vuln-a");
+    expect(names).toContain("vuln-c");
+    expect(names).not.toContain("safe-b");
   });
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,18 @@
+import { afterEach, vi } from "vitest";
+
+// Restore all mocks after each test to prevent leakage between tests
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Guard against accidental network calls in unit tests
+const originalFetch = globalThis.fetch;
+globalThis.fetch = ((...args: Parameters<typeof fetch>) => {
+  const url = typeof args[0] === "string" ? args[0] : args[0] instanceof URL ? args[0].href : "";
+  if (url.startsWith("http")) {
+    throw new Error(
+      `Unexpected network call to ${url} in unit test. Mock fetch or use test:integration.`,
+    );
+  }
+  return originalFetch(...args);
+}) as typeof fetch;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    setupFiles: ["test/setup.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts", "src/**/*.d.ts"],
+      reporter: ["text", "json", "html"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add vitest.config.ts with v8 coverage, test setup with mock cleanup and fetch guard, and test:coverage script (#24)
- Remove duplicate classifyLicense tests from checker.test.ts, replace tautological hash tests with known-value assertions (#21)
- Add report builder tests (7 tests) and rewrite vulnerability scanner tests with proper mocks (#22)

Closes #21, closes #22, closes #24

## Test plan
- [x] All 40 test files pass (237 tests)
- [x] Biome lint passes
- [x] Test setup file loads correctly (visible in duration output)
- [ ] Run `pnpm test:coverage` to verify coverage config works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage infrastructure with new test suites and improved mocking strategy
  * Added code coverage measurement capability with detailed reporting

* **Chores**
  * Configured test runner with setup automation and coverage reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->