### PR TITLE
fix: sync version metadata with package version

### DIFF
--- a/src/cli/output/cyclonedx.ts
+++ b/src/cli/output/cyclonedx.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { DependencyGraph } from "../../core/graph/types.js";
 import type { Report } from "../../core/report/types.js";
+import { AMINET_VERSION } from "../../version.js";
 
 interface CycloneDxComponent {
   type: string;
@@ -102,7 +103,7 @@ export function buildCycloneDxBom(report: Report, graph: DependencyGraph): Cyclo
     serialNumber: `urn:uuid:${randomUUID()}`,
     metadata: {
       timestamp: new Date().toISOString(),
-      tools: [{ vendor: "aminet", name: "aminet", version: "0.1.1" }],
+      tools: [{ vendor: "aminet", name: "aminet", version: AMINET_VERSION }],
     },
     components,
     dependencies,

--- a/src/cli/output/spdx.ts
+++ b/src/cli/output/spdx.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { DependencyGraph } from "../../core/graph/types.js";
 import type { Report } from "../../core/report/types.js";
+import { AMINET_VERSION } from "../../version.js";
 
 interface SpdxPackage {
   SPDXID: string;
@@ -112,7 +113,7 @@ export function buildSpdxDocument(report: Report, graph: DependencyGraph): SpdxD
     documentNamespace: `https://spdx.org/spdxdocs/${rootNode?.name ?? "root"}-${randomUUID()}`,
     creationInfo: {
       created: new Date().toISOString(),
-      creators: ["Tool: aminet-0.1.1"],
+      creators: [`Tool: aminet-${AMINET_VERSION}`],
       licenseListVersion: "3.22",
     },
     packages,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,14 @@ import { analyzeCommand } from "./cli/commands/analyze.js";
 import { cacheClearCommand, cachePruneCommand, cacheStatsCommand } from "./cli/commands/cache.js";
 import { initCommand } from "./cli/commands/init.js";
 import { reviewCommand } from "./cli/commands/review.js";
+import { AMINET_VERSION } from "./version.js";
 
 const program = new Command();
 
 program
   .name("aminet")
   .description("Software supply chain security tool for npm and Python packages")
-  .version("0.1.1");
+  .version(AMINET_VERSION);
 
 // analyze command
 program

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+
+function loadVersion(): string {
+  try {
+    const raw = readFileSync(new URL("../package.json", import.meta.url), "utf-8");
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    return typeof parsed.version === "string" ? parsed.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+export const AMINET_VERSION = loadVersion();

--- a/test/cli/output/cyclonedx.test.ts
+++ b/test/cli/output/cyclonedx.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildCycloneDxBom } from "../../../src/cli/output/cyclonedx.js";
 import type { DependencyGraph } from "../../../src/core/graph/types.js";
 import type { Report } from "../../../src/core/report/types.js";
+import { AMINET_VERSION } from "../../../src/version.js";
 
 function makeTestData() {
   const nodes = new Map();
@@ -105,5 +106,12 @@ describe("buildCycloneDxBom", () => {
     const bom = buildCycloneDxBom(report, graph);
 
     expect(bom.dependencies.length).toBeGreaterThan(0);
+  });
+
+  it("uses the current aminet version in tool metadata", () => {
+    const { report, graph } = makeTestData();
+    const bom = buildCycloneDxBom(report, graph);
+
+    expect(bom.metadata.tools[0].version).toBe(AMINET_VERSION);
   });
 });

--- a/test/cli/output/cyclonedx.test.ts
+++ b/test/cli/output/cyclonedx.test.ts
@@ -1,8 +1,12 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { buildCycloneDxBom } from "../../../src/cli/output/cyclonedx.js";
 import type { DependencyGraph } from "../../../src/core/graph/types.js";
 import type { Report } from "../../../src/core/report/types.js";
-import { AMINET_VERSION } from "../../../src/version.js";
+
+const packageVersion = JSON.parse(
+  readFileSync(new URL("../../../package.json", import.meta.url), "utf-8"),
+).version as string;
 
 function makeTestData() {
   const nodes = new Map();
@@ -112,6 +116,7 @@ describe("buildCycloneDxBom", () => {
     const { report, graph } = makeTestData();
     const bom = buildCycloneDxBom(report, graph);
 
-    expect(bom.metadata.tools[0].version).toBe(AMINET_VERSION);
+    expect(packageVersion).toBe("0.2.0");
+    expect(bom.metadata.tools[0].version).toBe(packageVersion);
   });
 });

--- a/test/cli/output/cyclonedx.test.ts
+++ b/test/cli/output/cyclonedx.test.ts
@@ -116,7 +116,6 @@ describe("buildCycloneDxBom", () => {
     const { report, graph } = makeTestData();
     const bom = buildCycloneDxBom(report, graph);
 
-    expect(packageVersion).toBe("0.2.0");
     expect(bom.metadata.tools[0].version).toBe(packageVersion);
   });
 });

--- a/test/cli/output/spdx.test.ts
+++ b/test/cli/output/spdx.test.ts
@@ -1,8 +1,12 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { buildSpdxDocument } from "../../../src/cli/output/spdx.js";
 import type { DependencyGraph } from "../../../src/core/graph/types.js";
 import type { Report } from "../../../src/core/report/types.js";
-import { AMINET_VERSION } from "../../../src/version.js";
+
+const packageVersion = JSON.parse(
+  readFileSync(new URL("../../../package.json", import.meta.url), "utf-8"),
+).version as string;
 
 function makeTestData() {
   const nodes = new Map();
@@ -113,6 +117,7 @@ describe("buildSpdxDocument", () => {
     const { report, graph } = makeTestData();
     const doc = buildSpdxDocument(report, graph);
 
-    expect(doc.creationInfo.creators).toContain(`Tool: aminet-${AMINET_VERSION}`);
+    expect(packageVersion).toBe("0.2.0");
+    expect(doc.creationInfo.creators).toContain(`Tool: aminet-${packageVersion}`);
   });
 });

--- a/test/cli/output/spdx.test.ts
+++ b/test/cli/output/spdx.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildSpdxDocument } from "../../../src/cli/output/spdx.js";
 import type { DependencyGraph } from "../../../src/core/graph/types.js";
 import type { Report } from "../../../src/core/report/types.js";
+import { AMINET_VERSION } from "../../../src/version.js";
 
 function makeTestData() {
   const nodes = new Map();
@@ -106,5 +107,12 @@ describe("buildSpdxDocument", () => {
     const expressRef = doc.packages[0].externalRefs.find((r) => r.referenceType === "purl");
     expect(expressRef).toBeDefined();
     expect(expressRef!.referenceLocator).toBe("pkg:npm/express@4.21.2");
+  });
+
+  it("uses the current aminet version in creation info", () => {
+    const { report, graph } = makeTestData();
+    const doc = buildSpdxDocument(report, graph);
+
+    expect(doc.creationInfo.creators).toContain(`Tool: aminet-${AMINET_VERSION}`);
   });
 });

--- a/test/cli/output/spdx.test.ts
+++ b/test/cli/output/spdx.test.ts
@@ -117,7 +117,6 @@ describe("buildSpdxDocument", () => {
     const { report, graph } = makeTestData();
     const doc = buildSpdxDocument(report, graph);
 
-    expect(packageVersion).toBe("0.2.0");
     expect(doc.creationInfo.creators).toContain(`Tool: aminet-${packageVersion}`);
   });
 });


### PR DESCRIPTION
## Summary

- replace hardcoded `0.1.1` metadata with a shared runtime version source
- use the shared version in the CLI, SPDX output, and CycloneDX output
- add regression tests for SPDX and CycloneDX version metadata

## Testing

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm test -- test/cli/output/spdx.test.ts test/cli/output/cyclonedx.test.ts`

## Risk

- [x] CLI output changed
- [x] JSON or SBOM output changed
- [ ] Cache or network behavior changed
- [ ] Documentation updated if needed

## Notes

- Fixes the version drift reported in #27.
- `node dist/index.js --version` now returns `0.2.0`.
