### PR TITLE
chore: add coderabbit repo config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+reviews:
+  review_status: false
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    base_branches:
+      - "^stg$"
+
+path_instructions:
+  - path: ".claude/skills/**"
+    instructions: |
+      Review skill trigger accuracy, workflow safety, branching-strategy alignment,
+      and whether the instructions create conflicting guidance or unnecessary context load.


### PR DESCRIPTION
## Summary

- add a repository-level CodeRabbit config file
- enable auto review for PRs targeting `stg`
- disable the review-skipped status message and add guidance for reviewing skill files

## Testing

- [ ] `bun run lint`
- [ ] `bun test`

## Risk

- [ ] CLI output changed
- [ ] JSON or SBOM output changed
- [ ] Cache or network behavior changed
- [x] Documentation or repository configuration updated

## Notes

- This changes review automation only. Runtime behavior is unchanged.
- Because the default branch is `main`, this should be treated as a staged repo-config change that becomes fully authoritative after release to `main`.