### PR TITLE
chore: add roadmap issue and implementation skills

### DIFF
--- a/.claude/skills/issue-implementation-train/SKILL.md
+++ b/.claude/skills/issue-implementation-train/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-implementation-train
-description: Implement an explicit set of GitHub issues end-to-end for this repository, using isolated worktrees, one branch per issue, targeted tests, pushes, and pull requests against `stg`. Use this when the user asks to implement specific issues, execute a planned batch of roadmap issues, or drive issue work through PR-ready completion. This skill is repo-specific: it never defaults to all open issues, requires an explicit issue set, and stops after initial PR creation rather than handling review follow-up.
+description: "Implement an explicit set of GitHub issues end-to-end for this repository, using isolated worktrees, one branch per issue, targeted tests, pushes, and pull requests against `stg`. Use this when the user asks to implement specific issues, execute a planned batch of roadmap issues, or drive issue work through PR-ready completion. This skill is repo-specific: it never defaults to all open issues, requires an explicit issue set, and stops after initial PR creation rather than handling review follow-up."
 argument-hint: "issues <numbers...> [--base stg]"
 allowed-tools: [Read, Glob, Grep, Bash(gh issue:*), Bash(gh pr:*), Bash(git worktree:*), Bash(git branch:*), Bash(git diff:*), Bash(git log:*), Bash(git push:*), Bash(git status:*), Bash(pnpm:*), Bash(node:*)]
 ---

--- a/.claude/skills/issue-implementation-train/SKILL.md
+++ b/.claude/skills/issue-implementation-train/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: issue-implementation-train
+description: Implement an explicit set of GitHub issues end-to-end for this repository, using isolated worktrees, one branch per issue, targeted tests, pushes, and pull requests against `stg`. Use this when the user asks to implement specific issues, execute a planned batch of roadmap issues, or drive issue work through PR-ready completion. This skill is repo-specific: it never defaults to all open issues, requires an explicit issue set, and stops after initial PR creation rather than handling review follow-up.
+argument-hint: "issues <numbers...> [--base stg]"
+allowed-tools: [Read, Glob, Grep, Bash(gh issue:*), Bash(gh pr:*), Bash(git worktree:*), Bash(git branch:*), Bash(git diff:*), Bash(git log:*), Bash(git push:*), Bash(git status:*), Bash(pnpm:*), Bash(node:*)]
+---
+
+# Issue Implementation Train
+
+Take an explicit batch of issues from intake to PR-ready completion.
+
+This skill is for **execution orchestration**, not planning. It is intentionally conservative: do not infer the target as "all open issues", and do not include post-PR review handling.
+
+## Inputs
+
+The argument must identify the issue set explicitly. Accept:
+
+- `issues 32 33 36`
+- `#32 #33 #36`
+- `issues from milestone A` only if the issue list can be resolved concretely from local context
+
+If the request does not clearly identify the issue set, stop and ask the user to name the issues.
+
+## Operating Model
+
+- one issue per worktree
+- one issue per branch
+- one worker per issue by default
+- base branch default: `stg`
+- completion target: implementation, relevant validation, commit, push, PR creation
+- review follow-up is out of scope; hand that to `review-respond` or the GitHub review skills later
+
+## Workflow
+
+### 1. Intake the issue set
+
+For each issue:
+
+- fetch the issue with `gh issue view <n>`
+- identify likely write scope
+- identify likely test scope
+- note whether it is code, docs, parser, CLI, workflow, or release-process work
+
+Build a short internal table with:
+
+- issue number
+- title
+- likely files/subsystems
+- overlap risk
+- validation scope
+
+### 2. Decide parallel vs serial lanes
+
+Parallelize across issues only when write scopes are independent.
+
+Default rules:
+
+- parser + parser in the same subsystem: serialize
+- parser + tests for that parser: serialize
+- docs-only or workflow-doc changes may run separately if they do not depend on implementation landing first
+- if two issues both touch shared output semantics, shared CLI entrypoints, or shared GitHub Action behavior, serialize
+
+When in doubt, choose serial execution.
+
+### 3. Create isolated worktrees and branches
+
+For each selected issue:
+
+- branch: `issue-<n>-<slug>`
+- worktree: `~/.codex/worktrees/<n>-<slug>`
+- base: `origin/stg` unless the user explicitly overrides
+
+Use non-interactive git only. Reuse an existing worktree only after checking that it is safe and already dedicated to the same issue.
+
+### 4. Spawn one worker per issue
+
+Each worker owns:
+
+- the assigned issue
+- the assigned worktree and branch
+- the implementation in that worktree
+- the narrowest relevant validation
+- commit, push, and PR creation
+
+Each worker prompt must include:
+
+- issue number and title
+- repo path
+- worktree path
+- branch name
+- explicit instruction not to revert unrelated changes
+- explicit instruction not to touch other workers' worktrees
+- completion requirements and required return values
+
+### 5. Validate before PR creation
+
+Require the worker to run the narrowest relevant tests that provide confidence.
+
+Default validation policy:
+
+- parser / resolver changes: focused unit tests plus broader affected suite if shared semantics changed
+- CLI / output changes: relevant command tests plus snapshot/output tests if present
+- docs-only changes: tests only if the docs depend on generated examples or checked snippets
+
+Workers must report:
+
+- what they ran
+- what they did not run
+- residual risks
+
+### 6. Push and open PRs
+
+For each completed issue:
+
+- commit with a concise imperative message
+- push the branch with upstream tracking
+- open a PR against `stg`
+- include `Closes #<n>` in the PR body
+
+Use a compact PR body:
+
+```md
+## Summary
+- <change 1>
+- <change 2>
+
+## Testing
+- <command>
+
+## Issue
+- Closes #<n>
+```
+
+### 7. Report portfolio status
+
+Return a compact end summary grouped by outcome:
+
+- completed with PR
+- blocked
+- intentionally serialized behind another issue
+
+For each issue, include:
+
+- issue number
+- branch
+- worktree path
+- tests run
+- PR URL or blocker
+
+## Repo Defaults
+
+- default base branch: `stg`
+- never default to "all open issues"
+- do not merge PRs from this skill
+- do not handle review feedback from this skill
+
+## Escalation Rules
+
+Ask the user only when one of these is true:
+
+- the issue set is not explicit
+- issue dependency order materially changes delivery and cannot be inferred
+- two issues overlap heavily enough that ownership is unclear
+- the target branch should not be `stg`
+
+Otherwise, proceed with the default model above.

--- a/.claude/skills/issue-implementation-train/SKILL.md
+++ b/.claude/skills/issue-implementation-train/SKILL.md
@@ -2,7 +2,7 @@
 name: issue-implementation-train
 description: "Implement an explicit set of GitHub issues end-to-end for this repository, using isolated worktrees, one branch per issue, targeted tests, pushes, and pull requests against `stg`. Use this when the user asks to implement specific issues, execute a planned batch of roadmap issues, or drive issue work through PR-ready completion. This skill is repo-specific: it never defaults to all open issues, requires an explicit issue set, and stops after initial PR creation rather than handling review follow-up."
 argument-hint: "issues <numbers...> [--base stg]"
-allowed-tools: [Read, Glob, Grep, Bash(gh issue:*), Bash(gh pr:*), Bash(git worktree:*), Bash(git branch:*), Bash(git diff:*), Bash(git log:*), Bash(git push:*), Bash(git status:*), Bash(pnpm:*), Bash(node:*)]
+allowed-tools: [Read, Glob, Grep, Bash(gh issue:*), Bash(gh pr:*), Bash(git worktree:*), Bash(git branch:*), Bash(git diff:*), Bash(git log:*), Bash(git push:*), Bash(git status:*), Bash(git add:*), Bash(git commit:*), Bash(pnpm:*), Bash(node:*)]
 ---
 
 # Issue Implementation Train
@@ -12,6 +12,10 @@ Take an explicit batch of issues from intake to PR-ready completion.
 This skill is for **execution orchestration**, not planning. It is intentionally conservative: do not infer the target as "all open issues", and do not include post-PR review handling.
 
 ## Inputs
+
+## Arguments
+
+The user invoked this with: `$ARGUMENTS`
 
 The argument must identify the issue set explicitly. Accept:
 
@@ -95,6 +99,7 @@ Each worker prompt must include:
 ### 5. Validate before PR creation
 
 Require the worker to run the narrowest relevant tests that provide confidence.
+If relevant validation fails, stop and mark the issue as `BLOCKED` with the failure details. Do not commit, push, or open a PR.
 
 Default validation policy:
 

--- a/.claude/skills/issue-implementation-train/SKILL.md
+++ b/.claude/skills/issue-implementation-train/SKILL.md
@@ -119,7 +119,7 @@ For each completed issue:
 
 - commit with a concise imperative message
 - push the branch with upstream tracking
-- open a PR against `stg`
+- open a PR against the resolved base branch (`stg` by default, or the user-provided override)
 - include `Closes #<n>` in the PR body
 
 Use a compact PR body:

--- a/.claude/skills/roadmap-issue-batch/SKILL.md
+++ b/.claude/skills/roadmap-issue-batch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-issue-batch
-description: Create a deduplicated batch of GitHub issues from roadmap documents, release plans, or report files. Use this when the user asks to turn a roadmap into issues, create missing issues from a plan, or bulk-file issues for a version or milestone. This skill is repo-specific: it prefers `report/` planning artifacts, uses the repository issue templates, writes issue content in English, and always previews the batch before creation unless the user explicitly opts out.
+description: "Create a deduplicated batch of GitHub issues from roadmap documents, release plans, or report files. Use this when the user asks to turn a roadmap into issues, create missing issues from a plan, or bulk-file issues for a version or milestone. This skill is repo-specific: it prefers `report/` planning artifacts, uses the repository issue templates, writes issue content in English, and always previews the batch before creation unless the user explicitly opts out."
 argument-hint: "from <version|horizon|report-path>"
 allowed-tools: [Read, Glob, Grep, Bash(gh issue:*), Bash(git status:*)]
 ---

--- a/.claude/skills/roadmap-issue-batch/SKILL.md
+++ b/.claude/skills/roadmap-issue-batch/SKILL.md
@@ -13,6 +13,10 @@ This skill is for **plan-to-issue conversion**, not general one-off issue drafti
 
 ## Inputs
 
+## Arguments
+
+The user invoked this with: `$ARGUMENTS`
+
 Interpret the argument in this order:
 
 - a specific report or roadmap file path under `report/`
@@ -50,12 +54,16 @@ Before proposing any issue:
 
 - search open issues for title or intent overlap
 - inspect recently closed issues when the roadmap item looks like a follow-up to already shipped work
+- compare the candidate against existing issues on:
+  - scope: what is included and excluded
+  - user-visible outcome: what changes for the user
+  - affected subsystem: command, workflow, or code area touched
 
 Use these rules:
 
 - if an open issue already covers the work, skip it
 - if a closed issue covered only an earlier MVP and the roadmap clearly describes additional work, create a new issue and mention the earlier issue in the body when helpful
-- when overlap is ambiguous, keep the candidate in the preview and flag it as a judgment call
+- when overlap is ambiguous, keep the candidate in the preview, include the checklist comparison, and flag it as an explicit judgment call
 
 ### 4. Build issue bodies from the template
 

--- a/.claude/skills/roadmap-issue-batch/SKILL.md
+++ b/.claude/skills/roadmap-issue-batch/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: roadmap-issue-batch
+description: Create a deduplicated batch of GitHub issues from roadmap documents, release plans, or report files. Use this when the user asks to turn a roadmap into issues, create missing issues from a plan, or bulk-file issues for a version or milestone. This skill is repo-specific: it prefers `report/` planning artifacts, uses the repository issue templates, writes issue content in English, and always previews the batch before creation unless the user explicitly opts out.
+argument-hint: "from <version|horizon|report-path>"
+allowed-tools: [Read, Glob, Grep, Bash(gh issue:*), Bash(git status:*)]
+---
+
+# Roadmap Issue Batch
+
+Turn an existing roadmap into a safe, reviewable batch of GitHub issues.
+
+This skill is for **plan-to-issue conversion**, not general one-off issue drafting. Keep the scope narrow: derive issues from roadmap material, detect duplicates, show the full batch, then create only after explicit confirmation unless the user clearly says to skip preview.
+
+## Inputs
+
+Interpret the argument in this order:
+
+- a specific report or roadmap file path under `report/`
+- a target version such as `0.3.0` or `1.0`
+- a planning horizon such as `next release` or `toward 1.0`
+- empty, meaning "find the most relevant roadmap artifact and draft issues from it"
+
+## Workflow
+
+### 1. Find the planning source
+
+Start with repository-local planning artifacts before guessing.
+
+- inspect `report/` for recent implementation plans, task lists, or roadmap notes
+- if needed, inspect `.claude/skills/roadmap-planning/SKILL.md` output expectations to match the repo's planning style
+- use existing open issues only as current-state input, not as the primary source of truth
+
+If multiple roadmap files are plausible, prefer the most recent one that clearly covers the requested version or horizon.
+
+### 2. Derive candidate issues
+
+Break the roadmap into actionable issues.
+
+Prefer one issue per coherent unit of delivery:
+
+- one behavior or capability change
+- one documentation or operational gap
+- one enabling design decision when it materially affects follow-on work
+
+Do not create separate issues for trivial substeps that belong naturally inside one implementation thread.
+
+### 3. Check for duplicates
+
+Before proposing any issue:
+
+- search open issues for title or intent overlap
+- inspect recently closed issues when the roadmap item looks like a follow-up to already shipped work
+
+Use these rules:
+
+- if an open issue already covers the work, skip it
+- if a closed issue covered only an earlier MVP and the roadmap clearly describes additional work, create a new issue and mention the earlier issue in the body when helpful
+- when overlap is ambiguous, keep the candidate in the preview and flag it as a judgment call
+
+### 4. Build issue bodies from the template
+
+Check `.github/ISSUE_TEMPLATE/feature_request.yml` and match its structure.
+
+Default body sections:
+
+- `Problem statement`
+- `Proposed solution`
+- `Alternatives considered`
+- `Example CLI or Action usage`
+
+Rules:
+
+- write the issue in English
+- default label: `enhancement`
+- keep the title concrete and outcome-focused
+- mention roadmap context only when it helps future triage
+
+### 5. Preview the full batch
+
+Always show one numbered preview block before creating, unless the user explicitly says to create without preview.
+
+The preview must include:
+
+- issue title
+- short 1-line purpose
+- candidate label
+- whether it is new or a follow-up to a closed issue
+- any skipped duplicates
+- assumptions used to split the work
+
+If the user asked for "all missing issues", also report which roadmap items were intentionally not turned into issues because they are too small, duplicate, or too vague.
+
+### 6. Create and report
+
+After confirmation:
+
+- create issues with `gh issue create`
+- report issue number, title, and URL in one compact summary
+
+If creation partially succeeds, stop and report what was created and what remains.
+
+## Repo Defaults
+
+- prefer roadmap artifacts under `report/`
+- issue language: English
+- default label: `enhancement`
+- do not create PRs from this skill
+- do not mutate roadmap files; this skill creates issues only
+
+## Output Format
+
+Use this preview format:
+
+```md
+## Preview: Roadmap Issue Batch
+
+Source: <file or inferred source>
+
+1. <title> — <1-line purpose>
+2. <title> — <1-line purpose>
+
+Skipped as duplicates:
+- #<n> <title>
+
+Assumptions:
+- <assumption>
+```
+
+Use this completion format:
+
+```md
+## Created Issues
+
+- #<n> <title> — <url>
+- #<n> <title> — <url>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ dist/
 tmp/
 *.pdf
 *.png
-report/
+/report/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 tmp/
 *.pdf
 *.png
+report/


### PR DESCRIPTION
## Summary

- add a `roadmap-issue-batch` skill for turning roadmap/report artifacts into deduplicated issue batches
- add an `issue-implementation-train` skill for executing explicit issue sets to PR-ready completion against `stg`
- ignore `report/` so local planning artifacts do not pollute normal git workflows

## Testing

- [x] Not run (skill docs and `.gitignore` only)

## Risk

- [ ] CLI output changed
- [ ] JSON or SBOM output changed
- [ ] Cache or network behavior changed
- [ ] Documentation updated if needed

## Notes

- repo-specific defaults are encoded in the skills, including `stg` as the default implementation PR base


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added workflow automation framework for GitHub issue execution with structured tracking, intelligent parallel processing for independent changes, and integrated PR workflows against the staging branch.
  * Added tooling to convert roadmap artifacts and planning documents into organized GitHub issues, including deduplication against existing issues and standardized templates.
  * Updated repository configuration to exclude generated report directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->