### PR TITLE
feat: add Python review and roadmap support

### DIFF
--- a/.github/workflows/ami-review.yml
+++ b/.github/workflows/ami-review.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     paths:
       - "package.json"
+      - "requirements.txt"
+      - "pyproject.toml"
       - "pnpm-lock.yaml"
       - "package-lock.json"
       - "bun.lock"
+      - "poetry.lock"
+      - "pdm.lock"
+      - "uv.lock"
 
 permissions:
   pull-requests: write

--- a/.github/workflows/ami-review.yml
+++ b/.github/workflows/ami-review.yml
@@ -36,7 +36,62 @@ jobs:
 
       - run: pnpm build
 
-      - uses: ./
+      - id: detect-manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")"
+          manifest_path=""
+          lockfile_path=""
+
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+
+            case "$file" in
+              */package.json|package.json|*/requirements.txt|requirements.txt|*/pyproject.toml|pyproject.toml)
+                manifest_path="$file"
+                break
+                ;;
+              */pnpm-lock.yaml|pnpm-lock.yaml|*/package-lock.json|package-lock.json|*/bun.lock|bun.lock)
+                dir="$(dirname "$file")"
+                candidate="$dir/package.json"
+                if [ "$dir" = "." ]; then
+                  candidate="package.json"
+                fi
+                if [ -f "$candidate" ]; then
+                  manifest_path="$candidate"
+                  lockfile_path="$file"
+                  break
+                fi
+                ;;
+              */poetry.lock|poetry.lock|*/pdm.lock|pdm.lock|*/uv.lock|uv.lock)
+                dir="$(dirname "$file")"
+                candidate="$dir/pyproject.toml"
+                if [ "$dir" = "." ]; then
+                  candidate="pyproject.toml"
+                fi
+                if [ -f "$candidate" ]; then
+                  manifest_path="$candidate"
+                  lockfile_path="$file"
+                  break
+                fi
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "path=$manifest_path" >> "$GITHUB_OUTPUT"
+          echo "lockfile-path=$lockfile_path" >> "$GITHUB_OUTPUT"
+
+      - if: steps.detect-manifest.outputs.path == ''
+        shell: bash
+        run: |
+          echo "No supported dependency manifest found for review."
+          exit 0
+
+      - if: steps.detect-manifest.outputs.path != ''
+        uses: ./
         with:
-          path: package.json
+          path: ${{ steps.detect-manifest.outputs.path }}
+          lockfile-path: ${{ steps.detect-manifest.outputs.lockfile-path }}
           security: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 tmp/
 *.pdf
 *.png
+/report/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 It analyzes dependency graphs, vulnerabilities, licenses, security signals, trust, freshness, provenance, and version pinning, then renders the result as terminal output, machine-readable JSON, SBOMs, or PR review comments.
 
+Roadmap and 1.0 criteria live in [`ROADMAP.md`](./ROADMAP.md).
+
 ## Status
 
 - Early project, pre-`1.0`
@@ -17,7 +19,7 @@ It analyzes dependency graphs, vulnerabilities, licenses, security signals, trus
 
 ## GitHub Action
 
-The main distribution target is GitHub Actions. `aminet` is designed to review npm dependency changes in pull requests and post or update a focused review comment.
+The main distribution target is GitHub Actions. `aminet` is designed to review dependency changes in pull requests and post or update a focused review comment for npm and supported Python manifest workflows.
 
 This repository ships a composite action in [`action.yml`](./action.yml).
 
@@ -57,14 +59,14 @@ This action is strongest when you want:
 
 Common inputs:
 
-- `path`: manifest path, usually `package.json`
+- `path`: manifest path, usually `package.json`, `requirements.txt`, or `pyproject.toml`
 - `depth`: maximum dependency depth to resolve
 - `dev`: include devDependencies in review (default: `"true"`)
 - `deny-license`: comma-separated SPDX IDs to block
 - `fail-on-vuln`: fail the job at or above a severity threshold
 - `security`: enable deeper security checks
 - `version`: pin the published `aminet` CLI version explicitly
-- `lockfile-path`: explicit path to lockfile (for monorepos)
+- `lockfile-path`: explicit path to lockfile (for monorepos, or to pin `pyproject.toml` review with `poetry.lock`, `pdm.lock`, or `uv.lock`)
 - `exclude-packages`: comma-separated packages to skip (supports wildcards like `@scope/*`)
 - `npm-token`: npm auth token for private registry access
 
@@ -78,6 +80,16 @@ For monorepo usage where `package.json` is in a sub-package:
 ```
 
 The review command automatically walks up parent directories to find lockfiles and reads the correct workspace section from pnpm lockfiles. Use `lockfile-path` when auto-detection does not work for your layout.
+
+For Python review from a manifest:
+
+```yaml
+      - uses: gorira-tatsu/aminet@v0.2.1
+        with:
+          path: pyproject.toml
+          lockfile-path: uv.lock
+          security: "true"
+```
 
 For repository-local usage during development:
 
@@ -163,6 +175,8 @@ Review dependency changes in a branch (includes devDependencies by default):
 ```bash
 npx aminet review package.json --base HEAD~1 --security
 npx aminet review package.json --base HEAD~1 --no-dev  # exclude devDependencies
+npx aminet review requirements.txt --base HEAD~1 --security
+npx aminet review pyproject.toml --base HEAD~1 --lockfile-path uv.lock
 ```
 
 Review with private packages (skip or authenticate):
@@ -180,6 +194,8 @@ npx aminet init --defaults         # non-interactive with sensible defaults
 npx aminet init --defaults --merge # merge defaults into existing config
 npx aminet init --defaults --force # overwrite existing config
 ```
+
+`init` does not embed private registry secrets by default. Use `NPM_TOKEN` in the environment when private packages should be analyzed, or `excludePackages` when internal packages should be skipped instead.
 
 Cache maintenance:
 
@@ -301,12 +317,15 @@ aminet can analyze Python dependencies from `requirements.txt` and `pyproject.to
 **Supported input formats:**
 - `requirements.txt` with pinned (`==`) or range specifiers
 - `pyproject.toml` with PEP 621 `[project].dependencies`
+- `poetry.lock`, `pdm.lock`, and `uv.lock` for `analyze`
 
 **Limitations:**
 - **Pinned versions (`==`) are scanned accurately.** Range specifiers resolve to the latest compatible version from PyPI, which may not match your actual environment. These are marked as best-effort in the analysis.
 - Dependencies with environment markers (e.g., `; python_version < '3.8'`) are skipped with a warning.
-- `poetry.lock`, `pdm.lock`, and `uv.lock` are not yet supported.
-- The `review` command does not yet support Python files.
+- Python lockfiles are currently `analyze` inputs, not standalone `review` inputs.
+- `review` supports `requirements.txt` and `pyproject.toml`. When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
+
+For the longer-term compatibility target, see [`ROADMAP.md`](./ROADMAP.md).
 
 ## Requirements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,45 @@
+# aminet Roadmap
+
+## Current release shape
+
+### 0.3.x
+
+- Python manifest review support for `requirements.txt` and `pyproject.toml`
+- clearer best-effort and marker-skipped messaging across analyze and review output
+- stronger parser coverage for real-world `pyproject.toml` layouts
+- better private registry guidance in `init`, README, and the GitHub Action
+- clearer degraded-mode behavior when the persistent cache is unavailable
+
+### 0.4.x
+
+- analyze support for `poetry.lock`, `pdm.lock`, and `uv.lock`
+- broader output consistency across npm and PyPI workflows
+- tighter semantics around Python lockfile-backed version pinning
+
+## Python lockfile support strategy
+
+- `requirements.txt` and `pyproject.toml` are the primary review inputs for Python projects.
+- `poetry.lock`, `pdm.lock`, and `uv.lock` are supported for `analyze`.
+- When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
+- Python lockfiles are not first-class `review` inputs yet; the review contract remains manifest-first so the changed direct dependencies are explicit in the PR diff.
+
+## 1.0 release criteria
+
+aminet should not be considered `1.0` until all of the following are true:
+
+1. Core workflows are stable:
+   - npm `analyze` and `review`
+   - Python `analyze` for manifests and supported lockfiles
+   - Python `review` for `requirements.txt` and `pyproject.toml`
+2. Output contracts are stable:
+   - JSON shape is treated as a compatibility surface
+   - review comment sections and key fields are consistent across npm and PyPI
+   - unsupported and best-effort cases are called out explicitly instead of failing silently
+3. Operational behavior is stable:
+   - private registry authentication and skip-pattern guidance is documented
+   - degraded cache mode is understandable and non-fatal for analyze/review
+   - release notes and action examples stay aligned with shipped behavior
+4. Validation is broad enough:
+   - regression coverage exists for npm and Python review flows
+   - parser fixtures cover realistic `pyproject.toml` and lockfile layouts
+   - the default `pnpm build`, `pnpm lint`, and `pnpm test` workflow is green before release

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: red
 inputs:
   path:
-    description: "Path to package.json"
+    description: "Path to the dependency manifest to review (package.json, requirements.txt, or pyproject.toml)"
     default: "package.json"
   depth:
     description: "Maximum dependency depth"
@@ -20,7 +20,7 @@ inputs:
     description: "Enable security deep analysis"
     default: "true"
   lockfile-path:
-    description: "Explicit path to lockfile (for monorepos)"
+    description: "Explicit path to lockfile (for monorepos or Python lockfiles used to pin pyproject review)"
     required: false
   dev:
     description: "Include devDependencies in review (default: true)"
@@ -75,9 +75,6 @@ runs:
         fi
         if [ "${{ inputs.security }}" = "true" ]; then
           ARGS+=("--security")
-        fi
-        if [ -n "${{ inputs.lockfile-path }}" ]; then
-          ARGS+=("--lockfile-path" "${{ inputs.lockfile-path }}")
         fi
         if [ -n "${{ inputs.lockfile-path }}" ]; then
           ARGS+=("--lockfile-path" "${{ inputs.lockfile-path }}")

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -12,9 +12,10 @@ import { resolveDependencyGraph } from "../../core/graph/resolver.js";
 import type { DependencyGraph } from "../../core/graph/types.js";
 import { checkDenyList } from "../../core/license/deny-list.js";
 import { getLicenseAlternatives } from "../../core/license/spdx.js";
-import { tryParseLockfile } from "../../core/lockfile/parser.js";
+import { parseLockfile, tryParseLockfile } from "../../core/lockfile/parser.js";
 import {
-  parsePyprojectDependencies,
+  parsePyprojectManifest,
+  parseRequirementsManifest,
   parseRequirementsTxt,
 } from "../../core/lockfile/python-parser.js";
 import type { PhantomDependency } from "../../core/phantom/scanner.js";
@@ -106,7 +107,12 @@ export function inferAnalyzeTarget(
   fileMode: boolean;
 } {
   const targetBasename = basename(target);
-  const isPythonFile = targetBasename === "requirements.txt" || targetBasename === "pyproject.toml";
+  const isPythonFile =
+    targetBasename === "requirements.txt" ||
+    targetBasename === "pyproject.toml" ||
+    targetBasename === "poetry.lock" ||
+    targetBasename === "pdm.lock" ||
+    targetBasename === "uv.lock";
   const ecosystem = isPythonFile ? (options.ecosystem ?? "pypi") : (options.ecosystem ?? "npm");
   const fileMode =
     options.file ||
@@ -119,7 +125,10 @@ export function inferAnalyzeTarget(
     target === "pnpm-lock.yaml" ||
     target === "bun.lock" ||
     target === "bun.lockb" ||
-    target === "package-lock.json";
+    target === "package-lock.json" ||
+    target === "poetry.lock" ||
+    target === "pdm.lock" ||
+    target === "uv.lock";
 
   return {
     ecosystem,
@@ -290,12 +299,13 @@ async function analyzePythonFile(
   const content = await readFile(filePath, "utf-8");
   const fileBaseName = basename(filePath);
 
-  let deps: Map<string, string>;
+  let deps = new Map<string, string>();
   let packageName = fileBaseName;
   let packageVersion = "0.0.0";
+  const analysisNotes: string[] = [];
 
   if (fileBaseName === "pyproject.toml") {
-    const parsed = parsePyprojectDependencies(content);
+    const parsed = parsePyprojectManifest(content);
     deps = new Map(parsed.dependencies);
     packageName = parsed.name ?? fileBaseName;
     packageVersion = parsed.version ?? packageVersion;
@@ -304,8 +314,59 @@ async function analyzePythonFile(
         deps.set(name, ver);
       }
     }
+    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+  } else if (fileBaseName === "requirements.txt") {
+    const parsed = parseRequirementsManifest(content);
+    deps = new Map(parsed.dependencies);
+    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+  } else if (
+    fileBaseName === "poetry.lock" ||
+    fileBaseName === "pdm.lock" ||
+    fileBaseName === "uv.lock"
+  ) {
+    const pyprojectPath = join(dirname(filePath), "pyproject.toml");
+    if (!existsSync(pyprojectPath)) {
+      console.error(
+        chalk.red(
+          `No pyproject.toml found alongside ${filePath}. Python lockfiles need a pyproject.toml.`,
+        ),
+      );
+      process.exit(1);
+    }
+
+    const pyprojectContent = await readFile(pyprojectPath, "utf-8");
+    const parsed = parsePyprojectManifest(pyprojectContent);
+    deps = new Map(parsed.dependencies);
+    packageName = parsed.name ?? fileBaseName;
+    packageVersion = parsed.version ?? packageVersion;
+    if (options.dev) {
+      for (const [name, ver] of parsed.devDependencies) {
+        deps.set(name, ver);
+      }
+    }
+    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
   } else {
     deps = parseRequirementsTxt(content);
+  }
+
+  const pythonLockfile =
+    fileBaseName === "poetry.lock" || fileBaseName === "pdm.lock" || fileBaseName === "uv.lock"
+      ? parseLockfile(fileBaseName, content)
+      : await tryParseLockfile(filePath, "pypi");
+  if (pythonLockfile) {
+    let pinned = 0;
+    for (const [name] of deps) {
+      const pinnedVersion = pythonLockfile.packages.get(name);
+      if (pinnedVersion) {
+        deps.set(name, pinnedVersion);
+        pinned++;
+      }
+    }
+    if (pinned > 0) {
+      analysisNotes.push(
+        `Pinned ${pinned}/${deps.size} Python direct dependencies from ${pythonLockfile.format}.`,
+      );
+    }
   }
 
   // Apply exclude patterns
@@ -347,7 +408,7 @@ async function analyzePythonFile(
     spinner.succeed(`Resolved ${result.graph.nodes.size} packages`);
   }
 
-  outputAndExit(result.graph, result.vulnerabilities, options, config);
+  outputAndExit(result.graph, result.vulnerabilities, options, config, { analysisNotes });
 }
 
 async function analyzePackage(
@@ -474,6 +535,7 @@ async function scanPhase(
 interface ExtraReportData {
   phantomDeps?: PhantomDependency[];
   pinningReport?: PinningReport;
+  analysisNotes?: string[];
 }
 
 async function outputAndExit(
@@ -520,6 +582,9 @@ async function outputAndExit(
   }
 
   const report = buildReport(graph, vulnerabilities, reportOptions);
+  if (extra?.analysisNotes && extra.analysisNotes.length > 0) {
+    report.analysisNotes = [...new Set(extra.analysisNotes)];
+  }
 
   // Output
   if (options.cyclonedx) {
@@ -690,6 +755,31 @@ function writeGitHubSummary(report: Report): void {
   } catch {
     // Non-critical
   }
+}
+
+function buildPythonAnalysisNotes(
+  skipped: Array<{ name?: string; spec: string; reason: "directive" | "marker" }>,
+  bestEffortDependencies: string[],
+): string[] {
+  const notes: string[] = [];
+  const markerSkipped = skipped.filter((entry) => entry.reason === "marker");
+
+  if (bestEffortDependencies.length > 0) {
+    notes.push(
+      `Best-effort resolution was used for: ${bestEffortDependencies.join(", ")}. Unpinned Python specs resolve against the latest compatible PyPI release and may not match the exact environment.`,
+    );
+  }
+
+  if (markerSkipped.length > 0) {
+    const names = markerSkipped
+      .map((entry) => entry.name ?? entry.spec)
+      .filter((value, index, all) => all.indexOf(value) === index);
+    notes.push(
+      `Skipped marker-gated Python dependencies: ${names.join(", ")}. Environment-specific requirements are not resolved in file-based analysis.`,
+    );
+  }
+
+  return notes;
 }
 
 function parsePackageSpec(spec: string): {

--- a/src/cli/commands/cache.ts
+++ b/src/cli/commands/cache.ts
@@ -75,7 +75,11 @@ function ensurePersistentCache(): boolean {
   }
 
   const reason = getPersistentCacheFailureReason() ?? "unknown error";
-  console.error(chalk.yellow(`Persistent cache unavailable: ${reason}`));
+  console.error(
+    chalk.yellow(
+      `Persistent cache unavailable: ${reason}. This cache command needs the on-disk database, but analyze/review still work without persistent cache.`,
+    ),
+  );
   process.exitCode = 1;
   return false;
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -82,7 +82,7 @@ const CONFIG_FIELDS: ConfigField[] = [
   },
   {
     key: "excludePackages",
-    prompt: "Packages to exclude (comma-separated, supports wildcards)",
+    prompt: "Packages to exclude (comma-separated internal/private patterns to skip)",
     type: "string[]",
     defaultValue: [],
     hint: "e.g., @my-org/*,legacy-pkg",
@@ -204,7 +204,7 @@ function handleNonInteractive(configPath: string, exists: boolean, options: Init
 
   writeFileSync(configPath, `${serializeConfig(config)}\n`, "utf-8");
   console.log(formatConfig(config));
-  console.log(chalk.dim("\nTip: Set NPM_TOKEN as an environment variable for private registries."));
+  printPrivateRegistryGuidance(config);
 }
 
 async function handleInteractive(configPath: string, exists: boolean): Promise<void> {
@@ -327,10 +327,23 @@ async function handleInteractive(configPath: string, exists: boolean): Promise<v
 
     writeFileSync(configPath, `${serializeConfig(finalConfig)}\n`, "utf-8");
     console.log(chalk.green(`\n  Wrote ${CONFIG_FILENAME}`));
-    console.log(
-      chalk.dim("  Tip: Set NPM_TOKEN as an environment variable for private registries."),
-    );
+    printPrivateRegistryGuidance(finalConfig, "  ");
   } finally {
     rl.close();
   }
+}
+
+function printPrivateRegistryGuidance(config: AmiConfig, indent = ""): void {
+  const prefix = indent ? `\n${indent}` : "\n";
+  const lines = [
+    `${prefix}Private registry guidance:`,
+    `${indent}- Set ${chalk.bold("NPM_TOKEN")} in the environment when private packages should be analyzed.`,
+    `${indent}- Use ${chalk.bold("excludePackages")} when internal packages should be skipped instead.`,
+  ];
+
+  if (config.excludePackages && config.excludePackages.length > 0) {
+    lines.push(`${indent}- Current exclude patterns: ${config.excludePackages.join(", ")}`);
+  }
+
+  console.log(chalk.dim(lines.join("\n")));
 }

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -6,6 +6,11 @@ import { buildReportForPackageSpec } from "../../core/analyzer.js";
 import { loadConfig } from "../../core/config/loader.js";
 import type { DependencyDiff } from "../../core/diff/types.js";
 import { parseLockfile } from "../../core/lockfile/parser.js";
+import {
+  type ParsedPythonManifest,
+  parsePyprojectManifest,
+  parseRequirementsManifest,
+} from "../../core/lockfile/python-parser.js";
 import { setNpmCacheEnabled, setNpmToken } from "../../core/registry/npm-client.js";
 import {
   buildReviewDiff,
@@ -32,6 +37,12 @@ export interface ReviewOptions extends AnalyzeOptions {
   lockfilePath?: string;
 }
 
+interface ReviewManifest {
+  ecosystem: "npm" | "pypi";
+  dependencies: Map<string, string>;
+  notes: string[];
+}
+
 export async function reviewCommand(target: string, options: ReviewOptions): Promise<void> {
   if (options.verbose) {
     setLogLevel("debug");
@@ -55,27 +66,26 @@ export async function reviewCommand(target: string, options: ReviewOptions): Pro
   const baseRef = options.base ?? "HEAD~1";
   const headRef = options.head; // undefined means working tree
 
+  const ecosystem = inferReviewEcosystem(target);
   const useSpinner = !options.ci;
-  const spinner = useSpinner ? ora("Loading package.json versions...").start() : null;
+  const spinner = useSpinner ? ora("Loading dependency manifests...").start() : null;
 
-  // Load base package.json
-  let basePkg: Record<string, unknown>;
+  let baseManifest: ReviewManifest;
   try {
-    basePkg = await loadPackageJson(target, baseRef);
-    if (spinner) spinner.text = "Loaded base package.json";
+    baseManifest = await loadReviewManifest(target, baseRef, options.dev, ecosystem);
+    if (spinner) spinner.text = "Loaded base dependency manifest";
   } catch (error) {
-    if (spinner) spinner.fail("Failed to load base package.json");
+    if (spinner) spinner.fail("Failed to load base dependency manifest");
     console.error(chalk.red(error instanceof Error ? error.message : String(error)));
     process.exit(1);
   }
 
-  // Load head package.json
-  let headPkg: Record<string, unknown>;
+  let headManifest: ReviewManifest;
   try {
-    headPkg = await loadPackageJson(target, headRef);
-    if (spinner) spinner.text = "Loaded head package.json";
+    headManifest = await loadReviewManifest(target, headRef, options.dev, ecosystem);
+    if (spinner) spinner.text = "Loaded head dependency manifest";
   } catch (error) {
-    if (spinner) spinner.fail("Failed to load head package.json");
+    if (spinner) spinner.fail("Failed to load head dependency manifest");
     console.error(chalk.red(error instanceof Error ? error.message : String(error)));
     process.exit(1);
   }
@@ -86,19 +96,14 @@ export async function reviewCommand(target: string, options: ReviewOptions): Pro
     dev: options.dev,
     noCache: options.noCache,
     security: options.security,
+    ecosystem,
   };
 
-  const baseLockfile = await loadAdjacentLockfile(target, baseRef, options.lockfilePath);
-  const headLockfile = await loadAdjacentLockfile(target, headRef, options.lockfilePath);
+  const baseLockfile = await loadAdjacentLockfile(target, baseRef, options.lockfilePath, ecosystem);
+  const headLockfile = await loadAdjacentLockfile(target, headRef, options.lockfilePath, ecosystem);
 
-  const baseDeps = collectDirectDependencies(
-    basePkg as Parameters<typeof collectDirectDependencies>[0],
-    options.dev,
-  );
-  const headDeps = collectDirectDependencies(
-    headPkg as Parameters<typeof collectDirectDependencies>[0],
-    options.dev,
-  );
+  const baseDeps = baseManifest.dependencies;
+  const headDeps = headManifest.dependencies;
   const baseResolved = resolveDirectDependencyVersions(baseDeps, baseLockfile);
   const headResolved = resolveDirectDependencyVersions(headDeps, headLockfile);
   const allChanges = diffDirectDependencies(baseDeps, headDeps, baseResolved, headResolved);
@@ -170,6 +175,8 @@ export async function reviewCommand(target: string, options: ReviewOptions): Pro
     diff = buildReviewDiff(changes, baseAnalyses, headAnalyses);
   }
 
+  diff.notes = [...new Set([...baseManifest.notes, ...headManifest.notes])];
+
   const markdown = renderMarkdownComment(diff);
 
   // Post to GitHub PR if credentials available
@@ -211,9 +218,107 @@ async function analyzePackageWithCache(
   return result;
 }
 
-async function loadPackageJson(filePath: string, ref?: string): Promise<Record<string, unknown>> {
+export function inferReviewEcosystem(target: string): "npm" | "pypi" {
+  const lower = target.toLowerCase();
+  if (
+    lower.endsWith("requirements.txt") ||
+    lower.endsWith("pyproject.toml") ||
+    lower.endsWith("poetry.lock") ||
+    lower.endsWith("pdm.lock") ||
+    lower.endsWith("uv.lock")
+  ) {
+    return "pypi";
+  }
+  return "npm";
+}
+
+async function loadReviewManifest(
+  filePath: string,
+  ref: string | undefined,
+  includeDev: boolean | undefined,
+  ecosystem: "npm" | "pypi",
+): Promise<ReviewManifest> {
   const content = await loadFileAtRefOrPath(filePath, ref);
-  return JSON.parse(content);
+  if (ecosystem === "pypi") {
+    return parsePythonReviewManifest(filePath, content, includeDev);
+  }
+
+  const pkg = JSON.parse(content) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  return {
+    ecosystem,
+    dependencies: collectDirectDependencies(pkg, includeDev),
+    notes: [],
+  };
+}
+
+export function parsePythonReviewManifest(
+  filePath: string,
+  content: string,
+  includeDev: boolean | undefined,
+): ReviewManifest {
+  const baseName = filePath.split(/[/\\]/).pop() ?? filePath;
+
+  if (baseName === "pyproject.toml") {
+    const parsed = parsePyprojectManifest(content);
+    const dependencies = new Map(parsed.dependencies);
+    if (includeDev) {
+      for (const [name, version] of parsed.devDependencies) {
+        dependencies.set(name, version);
+      }
+    }
+    return {
+      ecosystem: "pypi",
+      dependencies,
+      notes: buildPythonReviewNotes(parsed, includeDev),
+    };
+  }
+
+  if (baseName === "poetry.lock" || baseName === "pdm.lock" || baseName === "uv.lock") {
+    throw new Error(
+      `Review mode expects a Python manifest, not ${baseName}. Pass pyproject.toml or requirements.txt and use --lockfile-path if you need pinned versions.`,
+    );
+  }
+
+  const parsed = parseRequirementsManifest(content);
+  return {
+    ecosystem: "pypi",
+    dependencies: new Map(parsed.dependencies),
+    notes: buildPythonReviewNotes(parsed, includeDev),
+  };
+}
+
+export function buildPythonReviewNotes(
+  parsed: ParsedPythonManifest,
+  includeDev: boolean | undefined,
+): string[] {
+  const notes: string[] = [];
+
+  if (parsed.bestEffortDependencies.length > 0) {
+    notes.push(
+      `Best-effort resolution was used for: ${parsed.bestEffortDependencies.join(", ")}. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.`,
+    );
+  }
+
+  const markerSkipped = parsed.skipped.filter((entry) => entry.reason === "marker");
+  if (markerSkipped.length > 0) {
+    const names = markerSkipped
+      .map((entry) => entry.name ?? entry.spec)
+      .filter((value, index, all) => all.indexOf(value) === index);
+    notes.push(
+      `Skipped marker-gated Python dependencies: ${names.join(", ")}. Environment-specific requirements are not resolved in review mode.`,
+    );
+  }
+
+  if (includeDev && parsed.devDependencies.size > 0) {
+    notes.push(
+      `Included ${parsed.devDependencies.size} Python optional/dev dependencies in review mode.`,
+    );
+  }
+
+  return notes;
 }
 
 async function loadFileAtRefOrPath(filePath: string, ref?: string): Promise<string> {
@@ -267,12 +372,17 @@ function toGitRelativePath(filePath: string, gitRoot: string | null): string {
   return relPath.replace(/\\/g, "/");
 }
 
-const LOCKFILE_NAMES = ["pnpm-lock.yaml", "bun.lock", "package-lock.json"];
+function getReviewLockfileNames(ecosystem: "npm" | "pypi"): string[] {
+  return ecosystem === "pypi"
+    ? ["uv.lock", "poetry.lock", "pdm.lock"]
+    : ["pnpm-lock.yaml", "bun.lock", "package-lock.json"];
+}
 
 export async function loadAdjacentLockfile(
   packageJsonPath: string,
   ref?: string,
   explicitLockfilePath?: string,
+  ecosystem: "npm" | "pypi" = "npm",
 ): Promise<ReturnType<typeof parseLockfile> | null> {
   if (ref && (await isReadableFile(ref))) {
     ref = undefined;
@@ -308,7 +418,7 @@ export async function loadAdjacentLockfile(
   let dir = pkgDir;
 
   while (true) {
-    for (const lockfileName of LOCKFILE_NAMES) {
+    for (const lockfileName of getReviewLockfileNames(ecosystem)) {
       const candidate = join(dir, lockfileName);
       const gitRelativeCandidate = ref ? toGitRelativePath(candidate, gitRoot) : candidate;
       try {

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -379,7 +379,7 @@ function getReviewLockfileNames(ecosystem: "npm" | "pypi"): string[] {
 }
 
 export async function loadAdjacentLockfile(
-  packageJsonPath: string,
+  manifestPath: string,
   ref?: string,
   explicitLockfilePath?: string,
   ecosystem: "npm" | "pypi" = "npm",
@@ -388,7 +388,7 @@ export async function loadAdjacentLockfile(
     ref = undefined;
   }
 
-  const pkgDir = resolve(dirname(packageJsonPath));
+  const manifestDir = resolve(dirname(manifestPath));
 
   const gitRoot = await findGitRoot();
 
@@ -399,7 +399,7 @@ export async function loadAdjacentLockfile(
       const gitRelativePath = ref ? toGitRelativePath(absPath, gitRoot) : explicitLockfilePath;
       const content = await loadFileAtRefOrPath(gitRelativePath, ref);
       const lockfileDir = resolve(dirname(explicitLockfilePath));
-      const workspacePath = computeWorkspacePath(lockfileDir, pkgDir);
+      const workspacePath = computeWorkspacePath(lockfileDir, manifestDir);
       const parsed = parseLockfile(explicitLockfilePath, content, workspacePath);
       if (parsed && parsed.packages.size > 0) {
         return parsed;
@@ -414,8 +414,8 @@ export async function loadAdjacentLockfile(
     return null;
   }
 
-  // Walk up from package.json directory, stopping at git root
-  let dir = pkgDir;
+  // Walk up from the manifest directory, stopping at git root
+  let dir = manifestDir;
 
   while (true) {
     for (const lockfileName of getReviewLockfileNames(ecosystem)) {
@@ -423,7 +423,7 @@ export async function loadAdjacentLockfile(
       const gitRelativeCandidate = ref ? toGitRelativePath(candidate, gitRoot) : candidate;
       try {
         const content = await loadFileAtRefOrPath(gitRelativeCandidate, ref);
-        const workspacePath = computeWorkspacePath(dir, pkgDir);
+        const workspacePath = computeWorkspacePath(dir, manifestDir);
         const parsed = parseLockfile(candidate, content, workspacePath);
         if (parsed && parsed.packages.size > 0) {
           return parsed;

--- a/src/cli/output/markdown.ts
+++ b/src/cli/output/markdown.ts
@@ -36,6 +36,15 @@ export function renderMarkdownComment(diff: DependencyDiff): string {
   lines.push(`**Risk Level**: ${icon} ${capitalize(diff.summary.riskLevel)}`);
   lines.push("");
 
+  if (diff.notes && diff.notes.length > 0) {
+    lines.push("### Analysis Notes");
+    lines.push("");
+    for (const note of diff.notes) {
+      lines.push(`- ${note}`);
+    }
+    lines.push("");
+  }
+
   const keyAlerts = buildKeyAlerts(diff);
   if (keyAlerts.length > 0) {
     lines.push("### Key Alerts");

--- a/src/cli/output/table.ts
+++ b/src/cli/output/table.ts
@@ -112,6 +112,14 @@ export function renderTable(report: Report): void {
   console.log(table.toString());
   console.log();
 
+  if (report.analysisNotes && report.analysisNotes.length > 0) {
+    console.log(chalk.bold("Analysis Notes:"));
+    for (const note of report.analysisNotes) {
+      console.log(`  - ${note}`);
+    }
+    console.log();
+  }
+
   // Summary
   renderSummary(report);
 

--- a/src/core/diff/types.ts
+++ b/src/core/diff/types.ts
@@ -13,6 +13,7 @@ export interface DependencyDiff {
   resolvedVulnerabilities: VulnChange[];
   newSecuritySignals: SecuritySignalChange[];
   resolvedSecuritySignals: SecuritySignalChange[];
+  notes?: string[];
   summary: DiffSummary;
 }
 

--- a/src/core/lockfile/parser.ts
+++ b/src/core/lockfile/parser.ts
@@ -9,7 +9,13 @@ export interface LockfileEntry {
 }
 
 export interface LockfileResult {
-  format: "bun.lock" | "package-lock.json" | "pnpm-lock.yaml";
+  format:
+    | "bun.lock"
+    | "package-lock.json"
+    | "pnpm-lock.yaml"
+    | "poetry.lock"
+    | "pdm.lock"
+    | "uv.lock";
   packages: Map<string, string>; // name → exact version
 }
 
@@ -17,12 +23,14 @@ export interface LockfileResult {
  * Try to find and parse a lockfile adjacent to the given package.json path.
  * Returns null if no lockfile found.
  */
-export async function tryParseLockfile(packageJsonPath: string): Promise<LockfileResult | null> {
-  const dir = packageJsonPath.replace(/[/\\][^/\\]+$/, "");
+export async function tryParseLockfile(
+  manifestPath: string,
+  ecosystem: "npm" | "pypi" = "npm",
+): Promise<LockfileResult | null> {
+  const dir = manifestPath.replace(/[/\\][^/\\]+$/, "");
   const prefix = dir ? `${dir}/` : "";
 
-  // Prefer pnpm first, then npm, then Bun compatibility
-  for (const lockfileName of ["pnpm-lock.yaml", "package-lock.json", "bun.lock"]) {
+  for (const lockfileName of getLockfileNames(ecosystem)) {
     const lockfilePath = `${prefix}${lockfileName}`;
     try {
       const content = await readFile(lockfilePath, "utf-8");
@@ -59,7 +67,17 @@ export function parseLockfile(
   if (name === "pnpm-lock.yaml") {
     return parsePnpmLock(content, workspacePath);
   }
+  if (name === "poetry.lock" || name === "pdm.lock" || name === "uv.lock") {
+    return parsePythonPackageLock(name, content);
+  }
   return null;
+}
+
+function getLockfileNames(ecosystem: "npm" | "pypi"): string[] {
+  if (ecosystem === "pypi") {
+    return ["uv.lock", "poetry.lock", "pdm.lock"];
+  }
+  return ["pnpm-lock.yaml", "package-lock.json", "bun.lock"];
 }
 
 function parsePnpmLock(content: string, workspacePath?: string): LockfileResult | null {
@@ -215,4 +233,27 @@ function extractNameFromNodeModulesPath(path: string): string | null {
 function normalizePnpmVersion(version: string | undefined): string | null {
   if (!version) return null;
   return version.split("(")[0] ?? null;
+}
+
+function parsePythonPackageLock(
+  format: "poetry.lock" | "pdm.lock" | "uv.lock",
+  content: string,
+): LockfileResult | null {
+  try {
+    const packages = new Map<string, string>();
+    const blocks = content.split(/\n(?=\[\[package\]\])/g);
+
+    for (const block of blocks) {
+      if (!block.includes("[[package]]")) continue;
+      const nameMatch = block.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
+      const versionMatch = block.match(/^\s*version\s*=\s*["']([^"']+)["']/m);
+      if (!nameMatch || !versionMatch) continue;
+      packages.set(nameMatch[1], versionMatch[1]);
+    }
+
+    return { format, packages };
+  } catch {
+    logger.warn(`Failed to parse ${format}`);
+    return null;
+  }
 }

--- a/src/core/lockfile/parser.ts
+++ b/src/core/lockfile/parser.ts
@@ -20,7 +20,7 @@ export interface LockfileResult {
 }
 
 /**
- * Try to find and parse a lockfile adjacent to the given package.json path.
+ * Try to find and parse a lockfile adjacent to the given manifest path.
  * Returns null if no lockfile found.
  */
 export async function tryParseLockfile(
@@ -241,7 +241,7 @@ function parsePythonPackageLock(
 ): LockfileResult | null {
   try {
     const packages = new Map<string, string>();
-    const blocks = content.split(/\n(?=\[\[package\]\])/g);
+    const blocks = content.split(/\r?\n(?=\[\[package\]\])/g);
 
     for (const block of blocks) {
       if (!block.includes("[[package]]")) continue;

--- a/src/core/lockfile/python-parser.ts
+++ b/src/core/lockfile/python-parser.ts
@@ -1,63 +1,75 @@
 import { parsePep508 } from "../registry/pypi-client.js";
 
+export interface SkippedPythonDependency {
+  name?: string;
+  spec: string;
+  reason: "directive" | "marker";
+}
+
+export interface ParsedPythonManifest {
+  name?: string;
+  version?: string;
+  dependencies: Map<string, string>;
+  devDependencies: Map<string, string>;
+  skipped: SkippedPythonDependency[];
+  bestEffortDependencies: string[];
+}
+
+const DEV_LIKE_GROUPS = ["dev", "test", "tests", "docs", "doc", "lint", "typing", "typecheck"];
+
 /**
  * Parse a requirements.txt file and return a map of package name to version specifier.
- *
- * Handles:
- * - Pinned versions: `requests==2.31.0`
- * - Range specifiers: `flask>=2.0`
- * - Comments (`#`) and empty lines
- * - Skips `-r` includes, `-e` editables, and `--` flags
  */
 export function parseRequirementsTxt(content: string): Map<string, string> {
+  return parseRequirementsManifest(content).dependencies;
+}
+
+export function parseRequirementsManifest(content: string): ParsedPythonManifest {
   const packages = new Map<string, string>();
+  const skipped: SkippedPythonDependency[] = [];
 
   for (const rawLine of content.split("\n")) {
     const line = rawLine.trim();
 
-    // Skip empty lines
-    if (line === "") continue;
+    if (line === "" || line.startsWith("#")) continue;
 
-    // Skip comments
-    if (line.startsWith("#")) continue;
+    if (line.startsWith("-r ") || line.startsWith("-r\t")) {
+      skipped.push({ spec: line, reason: "directive" });
+      continue;
+    }
+    if (line.startsWith("-e ") || line.startsWith("-e\t")) {
+      skipped.push({ spec: line, reason: "directive" });
+      continue;
+    }
+    if (line.startsWith("--")) {
+      skipped.push({ spec: line, reason: "directive" });
+      continue;
+    }
 
-    // Skip -r includes, -e editables, and -- flags
-    if (line.startsWith("-r ") || line.startsWith("-r\t")) continue;
-    if (line.startsWith("-e ") || line.startsWith("-e\t")) continue;
-    if (line.startsWith("--")) continue;
-
-    // Strip inline comments: "requests==2.31.0 # pinned"
     const commentIdx = line.indexOf(" #");
     const cleaned = commentIdx !== -1 ? line.slice(0, commentIdx).trim() : line;
     if (cleaned === "") continue;
 
-    // Use PEP 508 parser for the dependency spec
-    const parsed = parsePep508(cleaned);
-    if (!parsed) continue;
-
-    const { name, versionSpec, hasMarker } = parsed;
-    if (hasMarker) continue;
-
-    // For pinned versions (==X.Y.Z), extract just the version number
-    const pinnedMatch = versionSpec.match(/^==\s*(.+)$/);
-    if (pinnedMatch) {
-      packages.set(name, pinnedMatch[1].trim());
-    } else {
-      // Keep the full specifier string for ranges
-      packages.set(name, versionSpec);
-    }
+    addParsedDep(cleaned, packages, skipped);
   }
 
-  return packages;
+  return {
+    dependencies: packages,
+    devDependencies: new Map(),
+    skipped,
+    bestEffortDependencies: collectBestEffortDependencies(packages),
+  };
 }
 
 /**
- * Parse a pyproject.toml [project] section using regex-based parsing (no TOML library).
+ * Parse a pyproject.toml file and return production/dev dependencies plus metadata.
  *
- * Extracts:
- * - `[project].name` and `[project].version`
- * - `[project].dependencies` array
- * - `[project.optional-dependencies].dev` array for dev deps
+ * Supported sections:
+ * - [project]
+ * - [project.optional-dependencies]
+ * - [dependency-groups]
+ * - [tool.poetry.dependencies]
+ * - [tool.poetry.group.<name>.dependencies]
  */
 export function parsePyprojectDependencies(content: string): {
   name?: string;
@@ -65,22 +77,48 @@ export function parsePyprojectDependencies(content: string): {
   dependencies: Map<string, string>;
   devDependencies: Map<string, string>;
 } {
+  const parsed = parsePyprojectManifest(content);
+  return {
+    name: parsed.name,
+    version: parsed.version,
+    dependencies: parsed.dependencies,
+    devDependencies: parsed.devDependencies,
+  };
+}
+
+export function parsePyprojectManifest(content: string): ParsedPythonManifest {
   const dependencies = new Map<string, string>();
   const devDependencies = new Map<string, string>();
+  const skipped: SkippedPythonDependency[] = [];
 
-  const name = extractStringField(content, "project", "name");
-  const version = extractStringField(content, "project", "version");
+  const name =
+    extractStringField(content, "project", "name") ??
+    extractStringField(content, "tool.poetry", "name");
+  const version =
+    extractStringField(content, "project", "version") ??
+    extractStringField(content, "tool.poetry", "version");
 
-  // Extract [project].dependencies array
-  const depsArray = extractTomlArray(content, "project", "dependencies");
-  for (const dep of depsArray) {
-    addParsedDep(dep, dependencies);
+  for (const dep of extractTomlArray(content, "project", "dependencies")) {
+    addParsedDep(dep, dependencies, skipped);
   }
 
-  // Extract [project.optional-dependencies].dev array
-  const devDepsArray = extractTomlArray(content, "project.optional-dependencies", "dev");
-  for (const dep of devDepsArray) {
-    addParsedDep(dep, devDependencies);
+  for (const group of DEV_LIKE_GROUPS) {
+    for (const dep of extractTomlArray(content, "project.optional-dependencies", group)) {
+      addParsedDep(dep, devDependencies, skipped);
+    }
+    for (const dep of extractTomlArray(content, "dependency-groups", group)) {
+      addParsedDep(dep, devDependencies, skipped);
+    }
+  }
+
+  parsePoetryDependencySection(content, "tool.poetry.dependencies", dependencies, skipped);
+  for (const group of DEV_LIKE_GROUPS) {
+    parsePoetryDependencySection(
+      content,
+      `tool.poetry.group.${group}.dependencies`,
+      devDependencies,
+      skipped,
+    );
   }
 
   return {
@@ -88,44 +126,91 @@ export function parsePyprojectDependencies(content: string): {
     version: version ?? undefined,
     dependencies,
     devDependencies,
+    skipped,
+    bestEffortDependencies: [
+      ...new Set([
+        ...collectBestEffortDependencies(dependencies),
+        ...collectBestEffortDependencies(devDependencies),
+      ]),
+    ],
   };
 }
 
-/**
- * Parse a PEP 508 dependency string and add it to the given map.
- */
-function addParsedDep(dep: string, map: Map<string, string>): void {
+function addParsedDep(
+  dep: string,
+  map: Map<string, string>,
+  skipped: SkippedPythonDependency[],
+): void {
   const parsed = parsePep508(dep);
   if (!parsed) return;
 
   const { name, versionSpec, hasMarker } = parsed;
-  if (hasMarker) return;
-  const pinnedMatch = versionSpec.match(/^==\s*(.+)$/);
-  if (pinnedMatch) {
-    map.set(name, pinnedMatch[1].trim());
-  } else {
-    map.set(name, versionSpec);
+  if (hasMarker) {
+    skipped.push({ name, spec: dep, reason: "marker" });
+    return;
+  }
+
+  map.set(name, normalizePythonVersionSpec(versionSpec));
+}
+
+function parsePoetryDependencySection(
+  content: string,
+  section: string,
+  map: Map<string, string>,
+  skipped: SkippedPythonDependency[],
+): void {
+  const sectionContent = extractSectionContent(content, section);
+  if (!sectionContent) return;
+
+  for (const rawLine of sectionContent.split("\n")) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+
+    const simpleMatch = line.match(/^([A-Za-z0-9._-]+)\s*=\s*["']([^"']+)["']/);
+    if (simpleMatch) {
+      const name = simpleMatch[1];
+      if (name.toLowerCase() === "python") continue;
+      map.set(name, normalizePythonVersionSpec(simpleMatch[2]));
+      continue;
+    }
+
+    const inlineTableMatch = line.match(/^([A-Za-z0-9._-]+)\s*=\s*\{(.+)\}$/);
+    if (!inlineTableMatch) continue;
+
+    const name = inlineTableMatch[1];
+    if (name.toLowerCase() === "python") continue;
+
+    const tableBody = inlineTableMatch[2];
+    const markerMatch = tableBody.match(/markers\s*=\s*["']([^"']+)["']/);
+    if (markerMatch) {
+      skipped.push({ name, spec: line, reason: "marker" });
+      continue;
+    }
+
+    const versionMatch = tableBody.match(/version\s*=\s*["']([^"']+)["']/);
+    if (versionMatch) {
+      map.set(name, normalizePythonVersionSpec(versionMatch[1]));
+    }
   }
 }
 
-/**
- * Extract a simple string field from a TOML section.
- * e.g. extractStringField(content, "project", "name") finds `name = "foo"` under `[project]`.
- */
-function extractStringField(content: string, section: string, field: string): string | null {
+function extractSectionContent(content: string, section: string): string | null {
   const sectionPattern = new RegExp(`^\\[${escapeRegex(section)}\\]\\s*$`, "m");
   const sectionMatch = sectionPattern.exec(content);
   if (!sectionMatch) return null;
 
   const afterSection = content.slice(sectionMatch.index + sectionMatch[0].length);
-
-  // Find the next section header (or end of string)
   const nextSectionMatch = afterSection.match(/^\[/m);
-  const sectionContent = nextSectionMatch
-    ? afterSection.slice(0, nextSectionMatch.index)
-    : afterSection;
+  return nextSectionMatch ? afterSection.slice(0, nextSectionMatch.index) : afterSection;
+}
 
-  // Match field = "value" or field = 'value'
+/**
+ * Extract a simple string field from a TOML section.
+ */
+function extractStringField(content: string, section: string, field: string): string | null {
+  const sectionContent = extractSectionContent(content, section);
+  if (!sectionContent) return null;
+
   const fieldPattern = new RegExp(`^${escapeRegex(field)}\\s*=\\s*["']([^"']*)["']`, "m");
   const fieldMatch = fieldPattern.exec(sectionContent);
   return fieldMatch ? fieldMatch[1] : null;
@@ -133,38 +218,18 @@ function extractStringField(content: string, section: string, field: string): st
 
 /**
  * Extract an array value from a TOML section.
- * Handles multi-line arrays like:
- *   dependencies = [
- *     "requests>=2.20",
- *     "flask>=2.0",
- *   ]
- * and single-line arrays like:
- *   dependencies = ["requests>=2.20", "flask>=2.0"]
  */
 function extractTomlArray(content: string, section: string, field: string): string[] {
-  const sectionPattern = new RegExp(`^\\[${escapeRegex(section)}\\]\\s*$`, "m");
-  const sectionMatch = sectionPattern.exec(content);
-  if (!sectionMatch) return [];
+  const sectionContent = extractSectionContent(content, section);
+  if (!sectionContent) return [];
 
-  const afterSection = content.slice(sectionMatch.index + sectionMatch[0].length);
-
-  // Find the next section header (or end of string)
-  const nextSectionMatch = afterSection.match(/^\[/m);
-  const sectionContent = nextSectionMatch
-    ? afterSection.slice(0, nextSectionMatch.index)
-    : afterSection;
-
-  // Find the field assignment: field = [...]
   const fieldStart = new RegExp(`^${escapeRegex(field)}\\s*=\\s*\\[`, "m");
   const fieldMatch = fieldStart.exec(sectionContent);
   if (!fieldMatch) return [];
 
-  // Find the content between [ and ]
   const bracketStart = fieldMatch.index + fieldMatch[0].length;
   const remaining = sectionContent.slice(bracketStart);
 
-  // Find the closing bracket, skipping brackets inside quoted strings
-  // (e.g., "package[extras]>=1.0")
   let closingBracket = -1;
   let inString = false;
   let stringChar = "";
@@ -183,18 +248,33 @@ function extractTomlArray(content: string, section: string, field: string): stri
   if (closingBracket === -1) return [];
 
   const arrayContent = remaining.slice(0, closingBracket);
-
-  // Extract quoted strings from the array content
   const items: string[] = [];
   const stringPattern = /["']([^"']*)["']/g;
-  for (const m of arrayContent.matchAll(stringPattern)) {
-    const value = m[1].trim();
-    if (value !== "") {
-      items.push(value);
-    }
+  for (const match of arrayContent.matchAll(stringPattern)) {
+    const value = match[1].trim();
+    if (value !== "") items.push(value);
   }
 
   return items;
+}
+
+function collectBestEffortDependencies(packages: Map<string, string>): string[] {
+  return [...packages.entries()]
+    .filter(([, spec]) => isBestEffortVersionSpec(spec))
+    .map(([name]) => name)
+    .sort();
+}
+
+function isBestEffortVersionSpec(versionSpec: string): boolean {
+  const trimmed = versionSpec.trim();
+  if (trimmed === "" || trimmed.toLowerCase() === "latest") return true;
+  return !/^\d+(\.\d+){0,2}([A-Za-z0-9._+-]+)?$/.test(trimmed);
+}
+
+function normalizePythonVersionSpec(versionSpec: string): string {
+  const trimmed = versionSpec.trim();
+  const pinnedMatch = trimmed.match(/^==\s*(.+)$/);
+  return pinnedMatch ? pinnedMatch[1].trim() : trimmed;
 }
 
 function escapeRegex(str: string): string {

--- a/src/core/lockfile/python-parser.ts
+++ b/src/core/lockfile/python-parser.ts
@@ -69,6 +69,7 @@ export function parseRequirementsManifest(content: string): ParsedPythonManifest
  * - [project.optional-dependencies]
  * - [dependency-groups]
  * - [tool.poetry.dependencies]
+ * - [tool.poetry.dev-dependencies]
  * - [tool.poetry.group.<name>.dependencies]
  */
 export function parsePyprojectDependencies(content: string): {
@@ -112,6 +113,7 @@ export function parsePyprojectManifest(content: string): ParsedPythonManifest {
   }
 
   parsePoetryDependencySection(content, "tool.poetry.dependencies", dependencies, skipped);
+  parsePoetryDependencySection(content, "tool.poetry.dev-dependencies", devDependencies, skipped);
   for (const group of DEV_LIKE_GROUPS) {
     parsePoetryDependencySection(
       content,
@@ -266,9 +268,9 @@ function collectBestEffortDependencies(packages: Map<string, string>): string[] 
 }
 
 function isBestEffortVersionSpec(versionSpec: string): boolean {
-  const trimmed = versionSpec.trim();
+  const trimmed = normalizePythonVersionSpec(versionSpec).trim();
   if (trimmed === "" || trimmed.toLowerCase() === "latest") return true;
-  return !/^\d+(\.\d+){0,2}([A-Za-z0-9._+-]+)?$/.test(trimmed);
+  return !/^\d+(?:\.\d+)*(?:[A-Za-z0-9._+-]+)?$/.test(trimmed);
 }
 
 function normalizePythonVersionSpec(versionSpec: string): string {

--- a/src/core/report/types.ts
+++ b/src/core/report/types.ts
@@ -52,6 +52,7 @@ export interface Report {
   maxDepth: number;
   entries: ReportEntry[];
   summary: ReportSummary;
+  analysisNotes?: string[];
   contextNotes?: ReportContextNote[];
   securitySignals?: SecuritySignal[];
   securitySummary?: {

--- a/src/core/store/database.ts
+++ b/src/core/store/database.ts
@@ -87,7 +87,7 @@ export function getDatabase(dbPath?: string): DatabaseLike {
 
     if (!warnedPersistentCacheFailure) {
       logger.warn(
-        `Persistent cache disabled for this run: ${persistentCacheFailureReason}. Continuing without cache.`,
+        `Persistent cache unavailable for this run: ${persistentCacheFailureReason}. Analyze and review will continue without the on-disk cache.`,
       );
       warnedPersistentCacheFailure = true;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ program
   .description("Analyze dependencies, licenses, and vulnerabilities")
   .argument(
     "<package>",
-    "Package (e.g., express@4.21.2) or file path (package.json, requirements.txt)",
+    "Package (e.g., express@4.21.2) or file path (package.json, pyproject.toml, poetry.lock)",
   )
   .option("--json", "Output as JSON")
   .option("--tree", "Output as dependency tree")
@@ -78,8 +78,8 @@ program
 program
   .command("ci")
   .description("CI-optimized analysis (alias for analyze --ci --json)")
-  .argument("<package>", "Package or --file path to analyze")
-  .option("--file", "Treat argument as path to package.json")
+  .argument("<package>", "Package or manifest/lockfile path to analyze")
+  .option("--file", "Treat argument as a manifest or lockfile path")
   .option("-d, --depth <number>", "Maximum dependency depth", parseInt)
   .option("--dev", "Include devDependencies")
   .option("--fail-on-vuln <severity>", "Exit non-zero on vulnerabilities (default: high)")
@@ -97,7 +97,7 @@ program
 program
   .command("review")
   .description("Compare dependency changes between two versions for PR review")
-  .argument("<path>", "Path to package.json")
+  .argument("<path>", "Path to package.json, requirements.txt, or pyproject.toml")
   .option("--base <ref>", "Base git ref or file path (default: HEAD~1)")
   .option("--head <ref>", "Head git ref or file path (default: working tree)")
   .option("--pr-number <number>", "GitHub PR number for comment posting")

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ program
   .description("Analyze dependencies, licenses, and vulnerabilities")
   .argument(
     "<package>",
-    "Package (e.g., express@4.21.2) or file path (package.json, pyproject.toml, poetry.lock)",
+    "Package (e.g., express@4.21.2) or file path (package.json, requirements.txt, pyproject.toml, poetry.lock, pdm.lock, uv.lock)",
   )
   .option("--json", "Output as JSON")
   .option("--tree", "Output as dependency tree")

--- a/test/cli/commands/review.test.ts
+++ b/test/cli/commands/review.test.ts
@@ -11,7 +11,29 @@ vi.mock("../../../src/utils/process.js", () => ({
   runCommand,
 }));
 
-import { computeWorkspacePath, loadAdjacentLockfile } from "../../../src/cli/commands/review.js";
+const { loadConfig } = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+const { getDatabase } = vi.hoisted(() => ({
+  getDatabase: vi.fn(),
+}));
+
+vi.mock("../../../src/core/config/loader.js", () => ({
+  loadConfig,
+}));
+
+vi.mock("../../../src/core/store/database.js", () => ({
+  getDatabase,
+}));
+
+import {
+  buildPythonReviewNotes,
+  computeWorkspacePath,
+  loadAdjacentLockfile,
+  parsePythonReviewManifest,
+  reviewCommand,
+} from "../../../src/cli/commands/review.js";
 
 describe("review lockfile helpers", () => {
   let tempRoot: string;
@@ -112,5 +134,121 @@ describe("review lockfile helpers", () => {
     );
 
     expect(result?.packages.get("vitest")).toBe("3.2.4");
+  });
+
+  it("finds adjacent Python lockfiles when reviewing pyproject.toml", async () => {
+    const appDir = join(tempRoot, "python-app");
+    await mkdir(appDir, { recursive: true });
+    await writeFile(
+      join(appDir, "pyproject.toml"),
+      '[project]\nname = "python-app"\nversion = "1.0.0"\ndependencies = ["fastapi>=0.116"]\n',
+    );
+    await writeFile(
+      join(appDir, "uv.lock"),
+      '[[package]]\nname = "fastapi"\nversion = "0.116.1"\n',
+    );
+
+    const result = await loadAdjacentLockfile(
+      join(appDir, "pyproject.toml"),
+      undefined,
+      undefined,
+      "pypi",
+    );
+
+    expect(result?.format).toBe("uv.lock");
+    expect(result?.packages.get("fastapi")).toBe("0.116.1");
+  });
+});
+
+describe("python review manifest helpers", () => {
+  it("builds review notes for requirements.txt manifests", () => {
+    const parsed = parsePythonReviewManifest(
+      "requirements.txt",
+      'requests==2.31.0\nfastapi>=0.116 ; python_version >= "3.10"\nurllib3\n',
+      false,
+    );
+
+    expect(parsed.dependencies.get("requests")).toBe("2.31.0");
+    expect(parsed.dependencies.get("urllib3")).toBe("");
+    expect(parsed.notes).toContain(
+      "Best-effort resolution was used for: urllib3. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.",
+    );
+    expect(parsed.notes).toContain(
+      "Skipped marker-gated Python dependencies: fastapi. Environment-specific requirements are not resolved in review mode.",
+    );
+  });
+
+  it("includes optional/dev groups in pyproject review mode when requested", () => {
+    const parsed = parsePythonReviewManifest(
+      "pyproject.toml",
+      `
+[project]
+name = "api"
+version = "1.0.0"
+dependencies = ["fastapi>=0.116"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+`,
+      true,
+    );
+
+    expect(parsed.dependencies.get("fastapi")).toBe(">=0.116");
+    expect(parsed.dependencies.get("pytest")).toBe(">=8.0");
+    expect(parsed.notes).toContain("Included 1 Python optional/dev dependencies in review mode.");
+  });
+
+  it("formats review notes from parsed Python manifests", () => {
+    const notes = buildPythonReviewNotes(
+      {
+        name: "api",
+        version: "1.0.0",
+        dependencies: new Map([["urllib3", ""]]),
+        devDependencies: new Map([["pytest", ">=8.0"]]),
+        skipped: [
+          {
+            name: "typing-extensions",
+            spec: 'typing-extensions; python_version < "3.11"',
+            reason: "marker",
+          },
+        ],
+        bestEffortDependencies: ["urllib3"],
+      },
+      true,
+    );
+
+    expect(notes).toEqual([
+      "Best-effort resolution was used for: urllib3. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.",
+      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not resolved in review mode.",
+      "Included 1 Python optional/dev dependencies in review mode.",
+    ]);
+  });
+
+  it("rejects standalone Python lockfiles in review mode", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "aminet-review-command-"));
+    const lockfilePath = join(tempRoot, "uv.lock");
+    await writeFile(lockfilePath, '[[package]]\nname = "fastapi"\nversion = "0.116.1"\n');
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        reviewCommand(lockfilePath, {
+          base: lockfilePath,
+          head: lockfilePath,
+          ci: true,
+        }),
+      ).rejects.toThrow("process.exit:1");
+
+      expect(stderrSpy.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
+        "Review mode expects a Python manifest",
+      );
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/test/cli/output/markdown.test.ts
+++ b/test/cli/output/markdown.test.ts
@@ -187,6 +187,19 @@ describe("renderMarkdownComment", () => {
     expect(md).toContain("HIGH");
   });
 
+  it("renders analysis notes when present", () => {
+    const diff = makeEmptyDiff();
+    diff.notes = [
+      "Best-effort resolution was used for: fastapi.",
+      "Skipped marker-gated Python dependencies: typing-extensions.",
+    ];
+
+    const md = renderMarkdownComment(diff);
+    expect(md).toContain("### Analysis Notes");
+    expect(md).toContain("Best-effort resolution was used for: fastapi.");
+    expect(md).toContain("Skipped marker-gated Python dependencies: typing-extensions.");
+  });
+
   it("renders declared and resolved versions for updated dependencies", () => {
     const diff = makeEmptyDiff();
     diff.updated = [

--- a/test/core/lockfile/parser.test.ts
+++ b/test/core/lockfile/parser.test.ts
@@ -180,4 +180,38 @@ importers:
       expect(result!.packages.has("lodash")).toBe(false);
     });
   });
+
+  describe("python lockfiles", () => {
+    const pythonLock = `
+[[package]]
+name = "fastapi"
+version = "0.116.1"
+
+[[package]]
+name = "pydantic"
+version = "2.11.7"
+`;
+
+    it("parses poetry.lock packages", () => {
+      const result = parseLockfile("poetry.lock", pythonLock);
+      expect(result).not.toBeNull();
+      expect(result!.format).toBe("poetry.lock");
+      expect(result!.packages.get("fastapi")).toBe("0.116.1");
+      expect(result!.packages.get("pydantic")).toBe("2.11.7");
+    });
+
+    it("parses pdm.lock packages", () => {
+      const result = parseLockfile("pdm.lock", pythonLock);
+      expect(result).not.toBeNull();
+      expect(result!.format).toBe("pdm.lock");
+      expect(result!.packages.get("fastapi")).toBe("0.116.1");
+    });
+
+    it("parses uv.lock packages", () => {
+      const result = parseLockfile("uv.lock", pythonLock);
+      expect(result).not.toBeNull();
+      expect(result!.format).toBe("uv.lock");
+      expect(result!.packages.get("pydantic")).toBe("2.11.7");
+    });
+  });
 });

--- a/test/core/lockfile/parser.test.ts
+++ b/test/core/lockfile/parser.test.ts
@@ -213,5 +213,15 @@ version = "2.11.7"
       expect(result!.format).toBe("uv.lock");
       expect(result!.packages.get("pydantic")).toBe("2.11.7");
     });
+
+    it("parses CRLF-separated Python lockfiles", () => {
+      const result = parseLockfile(
+        "poetry.lock",
+        '[[package]]\r\nname = "fastapi"\r\nversion = "0.116.1"\r\n\r\n[[package]]\r\nname = "pydantic"\r\nversion = "2.11.7"\r\n',
+      );
+      expect(result).not.toBeNull();
+      expect(result!.packages.get("fastapi")).toBe("0.116.1");
+      expect(result!.packages.get("pydantic")).toBe("2.11.7");
+    });
   });
 });

--- a/test/core/lockfile/python-parser.test.ts
+++ b/test/core/lockfile/python-parser.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   parsePyprojectDependencies,
+  parsePyprojectManifest,
+  parseRequirementsManifest,
   parseRequirementsTxt,
 } from "../../../src/core/lockfile/python-parser.js";
 
@@ -57,6 +59,12 @@ requests==2.31.0
       const result = parseRequirementsTxt("requests==2.31.0 # pinned\nflask>=3.0 # range\n");
       expect(result.get("requests")).toBe("2.31.0");
       expect(result.get("flask")).toBe(">=3.0");
+    });
+
+    it("tracks skipped directives and best-effort requirements", () => {
+      const result = parseRequirementsManifest(`-r base.txt\nrequests\nurllib3>=2.0\n`);
+      expect(result.skipped).toEqual([{ spec: "-r base.txt", reason: "directive" }]);
+      expect(result.bestEffortDependencies).toEqual(["requests", "urllib3"]);
     });
   });
 
@@ -146,6 +154,56 @@ dependencies = [
       expect(result.version).toBeUndefined();
       expect(result.dependencies.size).toBe(0);
       expect(result.devDependencies.size).toBe(0);
+    });
+
+    it("parses dependency-groups as dev dependencies", () => {
+      const result = parsePyprojectManifest(`
+[project]
+name = "dep-groups"
+version = "1.0.0"
+dependencies = ["requests>=2.31"]
+
+[dependency-groups]
+dev = ["pytest>=8.0"]
+docs = ["mkdocs==1.6.0"]
+`);
+
+      expect(result.dependencies.get("requests")).toBe(">=2.31");
+      expect(result.devDependencies.get("pytest")).toBe(">=8.0");
+      expect(result.devDependencies.get("mkdocs")).toBe("1.6.0");
+    });
+
+    it("parses Poetry dependencies and groups", () => {
+      const result = parsePyprojectManifest(`
+[tool.poetry]
+name = "poetry-app"
+version = "2.0.0"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.116.0"
+uvicorn = { version = "==0.35.0" }
+typing-extensions = { version = "^4.15.0", markers = "python_version < '3.11'" }
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.4.0"
+ruff = { version = "==0.12.0" }
+`);
+
+      expect(result.name).toBe("poetry-app");
+      expect(result.version).toBe("2.0.0");
+      expect(result.dependencies.get("fastapi")).toBe("^0.116.0");
+      expect(result.dependencies.get("uvicorn")).toBe("0.35.0");
+      expect(result.dependencies.has("python")).toBe(false);
+      expect(result.devDependencies.get("pytest")).toBe("^8.4.0");
+      expect(result.devDependencies.get("ruff")).toBe("0.12.0");
+      expect(result.skipped).toEqual([
+        {
+          name: "typing-extensions",
+          spec: 'typing-extensions = { version = "^4.15.0", markers = "python_version < \'3.11\'" }',
+          reason: "marker",
+        },
+      ]);
     });
   });
 });

--- a/test/core/lockfile/python-parser.test.ts
+++ b/test/core/lockfile/python-parser.test.ts
@@ -205,5 +205,29 @@ ruff = { version = "==0.12.0" }
         },
       ]);
     });
+
+    it("parses legacy Poetry dev-dependencies", () => {
+      const result = parsePyprojectManifest(`
+[tool.poetry]
+name = "legacy-poetry"
+version = "1.0.0"
+
+[tool.poetry.dependencies]
+fastapi = "^0.116.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "^8.4.0"
+black = "25.1.0"
+`);
+
+      expect(result.dependencies.get("fastapi")).toBe("^0.116.0");
+      expect(result.devDependencies.get("pytest")).toBe("^8.4.0");
+      expect(result.devDependencies.get("black")).toBe("25.1.0");
+    });
+
+    it("does not mark four-part pinned versions as best-effort", () => {
+      const result = parseRequirementsManifest("demo==1.2.3.4\n");
+      expect(result.bestEffortDependencies).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add Python review support for `requirements.txt` and `pyproject.toml`
- add Python lockfile parsing for `poetry.lock`, `pdm.lock`, and `uv.lock`
- align CLI, GitHub Action, workflow, docs, and roadmap criteria around the expanded Python support

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`

Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38
Closes #39
Closes #40
Closes #41
Closes #42
Closes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python ecosystem support for dependency review and analysis, including `requirements.txt`, `pyproject.toml`, and Python lockfiles (`poetry.lock`, `pdm.lock`, `uv.lock`).
  * Extended GitHub Actions workflow to trigger on Python dependency file changes.

* **Documentation**
  * Updated README with Python manifest examples and configuration guidance.
  * Added ROADMAP.md documenting project milestones and release criteria.

* **Chores**
  * Improved CLI error messaging for cache unavailability and private registry guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->