### PR TITLE
[codex] Improve matrix PR review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Common inputs:
 - `fail-on-vuln`: fail the job at or above a severity threshold
 - `security`: enable deeper security checks
 - `version`: pin the published `aminet` CLI version explicitly
+- `comment-id`: override the stable PR comment identifier used for updates (default: manifest path)
+- `comment-prefix`: override the human-readable label shown in the PR comment title (default: manifest path)
 - `lockfile-path`: explicit path to lockfile (for monorepos, or to pin `pyproject.toml` review with `poetry.lock`, `pdm.lock`, or `uv.lock`)
 - `exclude-packages`: comma-separated packages to skip (supports wildcards like `@scope/*`)
 - `npm-token`: npm auth token for private registry access
@@ -78,6 +80,26 @@ For monorepo usage where `package.json` is in a sub-package:
           path: packages/frontend/package.json
           lockfile-path: pnpm-lock.yaml
 ```
+
+For matrix-based monorepo review, each manifest can keep its own compact PR comment while remaining easy to identify:
+
+```yaml
+strategy:
+  matrix:
+    path:
+      - package.json
+      - apps/backend/package.json
+      - apps/frontend/package.json
+
+steps:
+  - uses: gorira-tatsu/aminet@v0.3.0
+    with:
+      path: ${{ matrix.path }}
+      comment-prefix: ${{ matrix.path }}
+      security: "true"
+```
+
+By default, aminet uses the manifest path as both the comment update key and the displayed label. Use `comment-id` only when you need to override the update key, and `comment-prefix` when you want a shorter or friendlier title while still showing the actual manifest path inside the comment body.
 
 The review command automatically walks up parent directories to find lockfiles and reads the correct workspace section from pnpm lockfiles. Use `lockfile-path` when auto-detection does not work for your layout.
 
@@ -274,11 +296,24 @@ npx aminet analyze express@4.21.2 --notices
 Representative review mode:
 
 ```text
-## aminet Dependency Review
+## aminet Dependency Review — `apps/frontend/package.json`
+Target: `apps/frontend/package.json`
+
+**Summary**: 1 updated dependency, 2 new vulnerabilities, 1 license change
+
+**Risk Level**: :red_circle: Critical
+
+### Key Alerts
+
+- 2 critical/high vulnerability alerts introduced
+- 1 dependency license alerts require review
+
+<details>
+<summary>Detailed review</summary>
 
 | Metric | Count |
 |--------|-------|
-| Added | 1 |
+| Added | 0 |
 | Removed | 0 |
 | Updated | 1 |
 | New Vulnerabilities | 2 |
@@ -291,11 +326,7 @@ Representative review mode:
 | Package | Version | Severity | Advisory | Fixed | Source | Summary |
 |---------|---------|----------|----------|-------|--------|---------|
 | minimist | 1.2.8 | CRITICAL | GHSA-... | 1.2.6 | osv | Prototype Pollution |
-
-### Updated Dependencies
-| Package | Declared | Resolved | License |
-|---------|----------|----------|---------|
-| react | ^18.2.0 -> ^18.3.0 | 18.3.1 -> 18.3.2 | MIT |
+</details>
 ```
 
 ## Output modes

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,12 @@ inputs:
   path:
     description: "Path to the dependency manifest to review (package.json, requirements.txt, or pyproject.toml)"
     default: "package.json"
+  comment-id:
+    description: "Stable identifier used to match and update the PR comment for this manifest (defaults to the manifest path)"
+    required: false
+  comment-prefix:
+    description: "Display label shown in the PR comment title (defaults to the manifest path)"
+    required: false
   depth:
     description: "Maximum dependency depth"
     required: false
@@ -66,6 +72,12 @@ runs:
 
         if [ -n "${{ inputs.depth }}" ]; then
           ARGS+=("--depth" "${{ inputs.depth }}")
+        fi
+        if [ -n "${{ inputs.comment-id }}" ]; then
+          ARGS+=("--comment-id" "${{ inputs.comment-id }}")
+        fi
+        if [ -n "${{ inputs.comment-prefix }}" ]; then
+          ARGS+=("--comment-prefix" "${{ inputs.comment-prefix }}")
         fi
         if [ -n "${{ inputs.deny-license }}" ]; then
           ARGS+=("--deny-license" "${{ inputs.deny-license }}")

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -26,7 +26,7 @@ import { fetchWithRetry } from "../../utils/http.js";
 import { logger, setLogLevel } from "../../utils/logger.js";
 import { runCommand } from "../../utils/process.js";
 import type { AnalyzeOptions } from "../options.js";
-import { renderMarkdownComment } from "../output/markdown.js";
+import { LEGACY_REVIEW_MARKER, renderMarkdownComment } from "../output/markdown.js";
 
 export interface ReviewOptions extends AnalyzeOptions {
   base?: string;
@@ -35,12 +35,21 @@ export interface ReviewOptions extends AnalyzeOptions {
   repo?: string;
   updateComment?: boolean;
   lockfilePath?: string;
+  commentId?: string;
+  commentPrefix?: string;
 }
 
 interface ReviewManifest {
   ecosystem: "npm" | "pypi";
   dependencies: Map<string, string>;
   notes: string[];
+}
+
+export interface ReviewCommentContext {
+  commentId: string;
+  marker: string;
+  targetPath: string;
+  label: string;
 }
 
 export async function reviewCommand(target: string, options: ReviewOptions): Promise<void> {
@@ -67,6 +76,18 @@ export async function reviewCommand(target: string, options: ReviewOptions): Pro
   const headRef = options.head; // undefined means working tree
 
   const ecosystem = inferReviewEcosystem(target);
+  const gitRoot = await findGitRoot();
+  let commentContext: ReviewCommentContext;
+  try {
+    commentContext = buildReviewCommentContext(target, {
+      gitRoot,
+      commentId: options.commentId,
+      commentPrefix: options.commentPrefix,
+    });
+  } catch (error) {
+    console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+    process.exit(1);
+  }
   const useSpinner = !options.ci;
   const spinner = useSpinner ? ora("Loading dependency manifests...").start() : null;
 
@@ -177,7 +198,11 @@ export async function reviewCommand(target: string, options: ReviewOptions): Pro
 
   diff.notes = [...new Set([...baseManifest.notes, ...headManifest.notes])];
 
-  const markdown = renderMarkdownComment(diff);
+  const markdown = renderMarkdownComment(diff, {
+    marker: commentContext.marker,
+    targetPath: commentContext.targetPath,
+    label: commentContext.label,
+  });
 
   // Post to GitHub PR if credentials available
   const token = process.env.GITHUB_TOKEN;
@@ -187,7 +212,13 @@ export async function reviewCommand(target: string, options: ReviewOptions): Pro
   if (token && repo && prNumber && options.updateComment !== false) {
     const prSpinner = useSpinner ? ora("Posting PR comment...").start() : null;
     try {
-      await postOrUpdateComment(repo, parseInt(prNumber, 10), markdown, token);
+      await postOrUpdateComment(
+        repo,
+        parseInt(prNumber, 10),
+        markdown,
+        token,
+        commentContext.marker,
+      );
       if (prSpinner) prSpinner.succeed("PR comment posted");
     } catch (error) {
       if (prSpinner) prSpinner.fail("Failed to post PR comment");
@@ -357,6 +388,36 @@ export function computeWorkspacePath(
   return rel && rel !== "." ? rel : undefined;
 }
 
+export function buildReviewCommentContext(
+  target: string,
+  options: {
+    gitRoot?: string | null;
+    commentId?: string;
+    commentPrefix?: string;
+  } = {},
+): ReviewCommentContext {
+  const gitRoot = options.gitRoot ?? null;
+  const targetPath = normalizeReviewPath(toGitRelativePath(target, gitRoot));
+  const commentId = normalizeReviewSingleLineInput(options.commentId, "comment-id") ?? targetPath;
+  const label =
+    normalizeReviewSingleLineInput(options.commentPrefix, "comment-prefix") ?? targetPath;
+
+  return {
+    commentId,
+    marker: buildReviewCommentMarker(commentId),
+    targetPath,
+    label,
+  };
+}
+
+export function buildReviewCommentMarker(commentId: string): string {
+  const normalizedCommentId = normalizeReviewSingleLineInput(commentId, "comment-id");
+  if (!normalizedCommentId) {
+    throw new Error("comment-id must not be empty");
+  }
+  return `<!-- aminet-review:id=${encodeURIComponent(normalizedCommentId)} -->`;
+}
+
 function toGitRelativePath(filePath: string, gitRoot: string | null): string {
   if (!gitRoot) {
     return filePath;
@@ -450,14 +511,14 @@ async function isReadableFile(path: string): Promise<boolean> {
   }
 }
 
-async function postOrUpdateComment(
+export async function postOrUpdateComment(
   repo: string,
   prNumber: number,
   body: string,
   token: string,
+  marker: string,
 ): Promise<void> {
   const apiBase = "https://api.github.com";
-  const marker = "<!-- aminet-review -->";
   const headers = {
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github.v3+json",
@@ -476,7 +537,7 @@ async function postOrUpdateComment(
     id: number;
     body: string;
   }>;
-  const existing = comments.find((c) => c.body.includes(marker));
+  const existing = findReviewCommentToUpdate(comments, marker);
 
   if (existing) {
     // Update existing comment
@@ -503,4 +564,44 @@ async function postOrUpdateComment(
     }
     logger.debug("Created new PR comment");
   }
+}
+
+function findReviewCommentToUpdate(
+  comments: Array<{
+    id: number;
+    body: string;
+  }>,
+  marker: string,
+) {
+  const exactMatch = comments.find((comment) => comment.body.includes(marker));
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const legacyMatches = comments.filter((comment) => comment.body.includes(LEGACY_REVIEW_MARKER));
+  return legacyMatches.length === 1 ? legacyMatches[0] : undefined;
+}
+
+function normalizeReviewSingleLineInput(
+  value: string | undefined,
+  optionName: "comment-id" | "comment-prefix",
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/[\r\n]/.test(trimmed)) {
+    throw new Error(`${optionName} must be a single line`);
+  }
+
+  return trimmed;
+}
+
+function normalizeReviewPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
 }

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -46,4 +46,7 @@ export interface ReviewOptions extends AnalyzeOptions {
   prNumber?: string;
   repo?: string;
   updateComment?: boolean;
+  lockfilePath?: string;
+  commentId?: string;
+  commentPrefix?: string;
 }

--- a/src/cli/output/markdown.ts
+++ b/src/cli/output/markdown.ts
@@ -1,7 +1,13 @@
 import type { DependencyDiff } from "../../core/diff/types.js";
 import type { LicenseReference } from "../../core/license/metadata.js";
 
-const MARKER = "<!-- aminet-review -->";
+export const LEGACY_REVIEW_MARKER = "<!-- aminet-review -->";
+
+export interface ReviewCommentRenderOptions {
+  marker?: string;
+  targetPath?: string;
+  label?: string;
+}
 
 const RISK_ICONS: Record<string, string> = {
   none: ":white_circle:",
@@ -11,11 +17,53 @@ const RISK_ICONS: Record<string, string> = {
   critical: ":red_circle:",
 };
 
-export function renderMarkdownComment(diff: DependencyDiff): string {
+export function renderMarkdownComment(
+  diff: DependencyDiff,
+  options: ReviewCommentRenderOptions = {},
+): string {
+  const marker = options.marker ?? LEGACY_REVIEW_MARKER;
+  const targetPath = normalizeInlineText(options.targetPath);
+  const label = normalizeInlineText(options.label) ?? targetPath;
   const lines: string[] = [];
 
-  lines.push(MARKER);
-  lines.push("## aminet Dependency Review");
+  lines.push(marker);
+  lines.push(`## aminet Dependency Review${label ? ` — \`${label}\`` : ""}`);
+  if (targetPath) {
+    lines.push("");
+    lines.push(`Target: \`${targetPath}\``);
+  }
+  lines.push("");
+  lines.push(`**Summary**: ${buildCompactSummary(diff)}`);
+  lines.push("");
+
+  const icon = RISK_ICONS[diff.summary.riskLevel] ?? ":white_circle:";
+  lines.push(`**Risk Level**: ${icon} ${capitalize(diff.summary.riskLevel)}`);
+  lines.push("");
+
+  const keyAlerts = buildKeyAlerts(diff);
+  if (keyAlerts.length > 0) {
+    lines.push("### Key Alerts");
+    lines.push("");
+    for (const alert of keyAlerts) {
+      lines.push(`- ${alert}`);
+    }
+    lines.push("");
+  }
+
+  if (hasNoDirectDependencyChanges(diff)) {
+    if (diff.notes && diff.notes.length > 0) {
+      lines.push("### Analysis Notes");
+      lines.push("");
+      for (const note of diff.notes) {
+        lines.push(`- ${note}`);
+      }
+      lines.push("");
+    }
+    return lines.join("\n");
+  }
+
+  lines.push("<details>");
+  lines.push("<summary>Detailed review</summary>");
   lines.push("");
   lines.push("| Metric | Count |");
   lines.push("|--------|-------|");
@@ -32,25 +80,11 @@ export function renderMarkdownComment(diff: DependencyDiff): string {
   }
   lines.push("");
 
-  const icon = RISK_ICONS[diff.summary.riskLevel] ?? ":white_circle:";
-  lines.push(`**Risk Level**: ${icon} ${capitalize(diff.summary.riskLevel)}`);
-  lines.push("");
-
   if (diff.notes && diff.notes.length > 0) {
     lines.push("### Analysis Notes");
     lines.push("");
     for (const note of diff.notes) {
       lines.push(`- ${note}`);
-    }
-    lines.push("");
-  }
-
-  const keyAlerts = buildKeyAlerts(diff);
-  if (keyAlerts.length > 0) {
-    lines.push("### Key Alerts");
-    lines.push("");
-    for (const alert of keyAlerts) {
-      lines.push(`- ${alert}`);
     }
     lines.push("");
   }
@@ -187,7 +221,39 @@ export function renderMarkdownComment(diff: DependencyDiff): string {
     lines.push("");
   }
 
+  lines.push("</details>");
+
   return lines.join("\n");
+}
+
+function hasNoDirectDependencyChanges(diff: DependencyDiff): boolean {
+  return (
+    diff.summary.addedCount === 0 &&
+    diff.summary.removedCount === 0 &&
+    diff.summary.updatedCount === 0 &&
+    diff.summary.newVulnCount === 0 &&
+    diff.summary.resolvedVulnCount === 0 &&
+    diff.summary.newSecuritySignalCount === 0 &&
+    diff.summary.resolvedSecuritySignalCount === 0 &&
+    diff.summary.licenseChangeCount === 0
+  );
+}
+
+function buildCompactSummary(diff: DependencyDiff): string {
+  if (hasNoDirectDependencyChanges(diff)) {
+    return "No direct dependency changes detected.";
+  }
+
+  const parts = [
+    formatCount(diff.summary.addedCount, "added dependency", "added dependencies"),
+    formatCount(diff.summary.removedCount, "removed dependency", "removed dependencies"),
+    formatCount(diff.summary.updatedCount, "updated dependency", "updated dependencies"),
+    formatCount(diff.summary.newVulnCount, "new vulnerability", "new vulnerabilities"),
+    formatCount(diff.summary.newSecuritySignalCount, "new security signal", "new security signals"),
+    formatCount(diff.summary.licenseChangeCount, "license change", "license changes"),
+  ].filter((part): part is string => part !== null);
+
+  return parts.join(", ");
 }
 
 function filterVisibleSecuritySignals(
@@ -332,4 +398,18 @@ function formatTransition(previous?: string | null, next?: string | null): strin
 
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatCount(count: number, singular: string, plural: string): string | null {
+  if (count === 0) {
+    return null;
+  }
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function normalizeInlineText(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return value.trim().replace(/\r?\n/g, " ").replace(/`/g, "\\`");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,8 @@ program
   .option("--pr-number <number>", "GitHub PR number for comment posting")
   .option("--repo <owner/name>", "GitHub repository (e.g., user/repo)")
   .option("--update-comment", "Update existing aminet comment instead of creating new")
+  .option("--comment-id <id>", "Stable comment identifier for PR comment updates")
+  .option("--comment-prefix <label>", "Display label for PR comment titles")
   .option("-d, --depth <number>", "Maximum dependency depth", parseInt)
   .option("-c, --concurrency <number>", "Maximum concurrent requests", parseInt)
   .option("--no-dev", "Exclude devDependencies from review")

--- a/test/cli/commands/review.test.ts
+++ b/test/cli/commands/review.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LEGACY_REVIEW_MARKER } from "../../../src/cli/output/markdown.js";
 
 const { runCommand } = vi.hoisted(() => ({
   runCommand: vi.fn(),
@@ -19,6 +20,10 @@ const { getDatabase } = vi.hoisted(() => ({
   getDatabase: vi.fn(),
 }));
 
+const { fetchWithRetry } = vi.hoisted(() => ({
+  fetchWithRetry: vi.fn(),
+}));
+
 vi.mock("../../../src/core/config/loader.js", () => ({
   loadConfig,
 }));
@@ -27,11 +32,18 @@ vi.mock("../../../src/core/store/database.js", () => ({
   getDatabase,
 }));
 
+vi.mock("../../../src/utils/http.js", () => ({
+  fetchWithRetry,
+}));
+
 import {
   buildPythonReviewNotes,
+  buildReviewCommentContext,
+  buildReviewCommentMarker,
   computeWorkspacePath,
   loadAdjacentLockfile,
   parsePythonReviewManifest,
+  postOrUpdateComment,
   reviewCommand,
 } from "../../../src/cli/commands/review.js";
 
@@ -42,6 +54,7 @@ describe("review lockfile helpers", () => {
     tempRoot = await mkdtemp(join(tmpdir(), "aminet-review-"));
     runCommand.mockReset();
     runCommand.mockResolvedValue({ exitCode: 0, stdout: `${tempRoot}\n`, stderr: "" });
+    fetchWithRetry.mockReset();
   });
 
   afterEach(async () => {
@@ -157,6 +170,101 @@ describe("review lockfile helpers", () => {
 
     expect(result?.format).toBe("uv.lock");
     expect(result?.packages.get("fastapi")).toBe("0.116.1");
+  });
+});
+
+describe("review comment helpers", () => {
+  it("builds per-manifest comment context from the git-relative path", () => {
+    const context = buildReviewCommentContext("/repo/apps/backend/package.json", {
+      gitRoot: "/repo",
+    });
+
+    expect(context.commentId).toBe("apps/backend/package.json");
+    expect(context.targetPath).toBe("apps/backend/package.json");
+    expect(context.label).toBe("apps/backend/package.json");
+    expect(context.marker).toBe("<!-- aminet-review:id=apps%2Fbackend%2Fpackage.json -->");
+  });
+
+  it("uses comment-prefix only for display and comment-id only for updates", () => {
+    const context = buildReviewCommentContext("apps/backend/package.json", {
+      commentId: "backend-review",
+      commentPrefix: "Backend",
+    });
+
+    expect(context.commentId).toBe("backend-review");
+    expect(context.label).toBe("Backend");
+    expect(context.marker).toBe(buildReviewCommentMarker("backend-review"));
+  });
+
+  it("rejects multiline comment identifiers", () => {
+    expect(() =>
+      buildReviewCommentContext("apps/backend/package.json", {
+        commentId: "backend\nreview",
+      }),
+    ).toThrow("comment-id must be a single line");
+  });
+});
+
+describe("postOrUpdateComment", () => {
+  beforeEach(() => {
+    fetchWithRetry.mockReset();
+  });
+
+  it("updates a matching marker comment", async () => {
+    const marker = buildReviewCommentMarker("apps/backend/package.json");
+    fetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: 42, body: `${marker}\nold body` }],
+    });
+    fetchWithRetry.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await postOrUpdateComment("gorira-tatsu/aminet", 46, `${marker}\nnew body`, "token", marker);
+
+    expect(fetchWithRetry).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/gorira-tatsu/aminet/issues/comments/42",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("migrates a single legacy comment to the new marker", async () => {
+    const marker = buildReviewCommentMarker("apps/frontend/package.json");
+    fetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: 7, body: `${LEGACY_REVIEW_MARKER}\nold body` }],
+    });
+    fetchWithRetry.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await postOrUpdateComment("gorira-tatsu/aminet", 46, `${marker}\nnew body`, "token", marker);
+
+    expect(fetchWithRetry).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/gorira-tatsu/aminet/issues/comments/7",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("creates a new comment when legacy comments are ambiguous", async () => {
+    const marker = buildReviewCommentMarker("apps/frontend/package.json");
+    fetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { id: 1, body: `${LEGACY_REVIEW_MARKER}\nfirst` },
+        { id: 2, body: `${LEGACY_REVIEW_MARKER}\nsecond` },
+      ],
+    });
+    fetchWithRetry.mockResolvedValueOnce({ ok: true, status: 201 });
+
+    await postOrUpdateComment("gorira-tatsu/aminet", 46, `${marker}\nnew body`, "token", marker);
+
+    expect(fetchWithRetry).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/gorira-tatsu/aminet/issues/46/comments",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 });
 

--- a/test/cli/output/markdown.test.ts
+++ b/test/cli/output/markdown.test.ts
@@ -33,6 +33,21 @@ describe("renderMarkdownComment", () => {
     expect(md).toContain("<!-- aminet-review -->");
   });
 
+  it("renders a compact empty state for unchanged manifests", () => {
+    const diff = makeEmptyDiff();
+    const md = renderMarkdownComment(diff, {
+      marker: "<!-- aminet-review:id=apps%2Fbackend%2Fpackage.json -->",
+      targetPath: "apps/backend/package.json",
+      label: "Backend",
+    });
+
+    expect(md).toContain("## aminet Dependency Review — `Backend`");
+    expect(md).toContain("Target: `apps/backend/package.json`");
+    expect(md).toContain("**Summary**: No direct dependency changes detected.");
+    expect(md).not.toContain("| Metric | Count |");
+    expect(md).not.toContain("<details>");
+  });
+
   it("includes summary table", () => {
     const diff = makeEmptyDiff();
     diff.summary.addedCount = 3;
@@ -63,6 +78,7 @@ describe("renderMarkdownComment", () => {
       },
     ];
     const md = renderMarkdownComment(diff);
+    expect(md).toContain("<details>");
     expect(md).toContain("| Added | 3 |");
     expect(md).toContain("## aminet Dependency Review");
   });


### PR DESCRIPTION
## Summary
- add manifest-specific PR comment markers and optional `comment-id` / `comment-prefix` inputs for review mode
- switch review comments to a compact-first layout so matrix runs stay readable, especially when a manifest has no direct dependency changes
- keep compatibility with legacy `<!-- aminet-review -->` comments when there is a single existing legacy comment to migrate

## Why
Issue #46 showed that matrix-based GitHub Action runs produced multiple indistinguishable aminet comments on the same PR. The old layout also made zero-change manifests noisy because each job posted a full metrics table.

## Impact
- matrix jobs now update distinct comments per manifest path by default
- users can override the update key with `comment-id` and the displayed title label with `comment-prefix`
- unchanged manifests render a short summary instead of a large empty table

## Root Cause
The review flow used a single fixed marker (`<!-- aminet-review -->`) and a fixed heading for every comment, so all matrix jobs looked the same and update matching could not differentiate manifests.

## Validation
- `pnpm vitest test/cli/output/markdown.test.ts test/cli/commands/review.test.ts --run`
- `pnpm build`
- `pnpm exec biome check src/cli/output/markdown.ts src/cli/commands/review.ts src/index.ts src/cli/options.ts action.yml README.md test/cli/output/markdown.test.ts test/cli/commands/review.test.ts`

Closes #46