### PR TITLE
feat: harden pyproject dependency parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,12 +316,17 @@ aminet can analyze Python dependencies from `requirements.txt` and `pyproject.to
 
 **Supported input formats:**
 - `requirements.txt` with pinned (`==`) or range specifiers
-- `pyproject.toml` with PEP 621 `[project].dependencies`
+- `pyproject.toml` with these supported scopes:
+  - PEP 621 `[project].dependencies`
+  - `[project.optional-dependencies]` for dev-like groups: `dev`, `test`, `tests`, `docs`, `doc`, `lint`, `typing`, `typecheck`
+  - `[dependency-groups]` for the same dev-like groups, including `include-group`
+  - Poetry `[tool.poetry.dependencies]`, `[tool.poetry.dev-dependencies]`, and `[tool.poetry.group.<name>.dependencies]`
 - `poetry.lock`, `pdm.lock`, and `uv.lock` for `analyze`
 
 **Limitations:**
 - **Pinned versions (`==`) are scanned accurately.** Range specifiers resolve to the latest compatible version from PyPI, which may not match your actual environment. These are marked as best-effort in the analysis.
 - Dependencies with environment markers (e.g., `; python_version < '3.8'`) are skipped with a warning.
+- Poetry dependencies without a version-bearing specifier, such as local `path` or `git` sources, are currently out of scope for review parsing.
 - Python lockfiles are currently `analyze` inputs, not standalone `review` inputs.
 - `review` supports `requirements.txt` and `pyproject.toml`. When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "commander": "^13.1.0",
     "ora": "^8.2.0",
     "semver": "^7.7.1",
+    "smol-toml": "^1.6.1",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       semver:
         specifier: ^7.7.1
         version: 7.7.4
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
       yaml:
         specifier: ^2.8.1
         version: 2.8.2
@@ -724,6 +727,10 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1447,6 +1454,8 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/core/lockfile/python-parser.ts
+++ b/src/core/lockfile/python-parser.ts
@@ -1,3 +1,5 @@
+import type { TomlTable, TomlValue } from "smol-toml";
+import { parse as parseToml } from "smol-toml";
 import { parsePep508 } from "../registry/pypi-client.js";
 
 export interface SkippedPythonDependency {
@@ -91,33 +93,48 @@ export function parsePyprojectManifest(content: string): ParsedPythonManifest {
   const dependencies = new Map<string, string>();
   const devDependencies = new Map<string, string>();
   const skipped: SkippedPythonDependency[] = [];
+  const parsedToml = safeParseToml(content);
 
   const name =
-    extractStringField(content, "project", "name") ??
-    extractStringField(content, "tool.poetry", "name");
+    readStringPath(parsedToml, ["project", "name"]) ??
+    readStringPath(parsedToml, ["tool", "poetry", "name"]);
   const version =
-    extractStringField(content, "project", "version") ??
-    extractStringField(content, "tool.poetry", "version");
+    readStringPath(parsedToml, ["project", "version"]) ??
+    readStringPath(parsedToml, ["tool", "poetry", "version"]);
 
-  for (const dep of extractTomlArray(content, "project", "dependencies")) {
+  for (const dep of readStringArrayPath(parsedToml, ["project", "dependencies"])) {
     addParsedDep(dep, dependencies, skipped);
   }
 
   for (const group of DEV_LIKE_GROUPS) {
-    for (const dep of extractTomlArray(content, "project.optional-dependencies", group)) {
+    for (const dep of readStringArrayPath(parsedToml, [
+      "project",
+      "optional-dependencies",
+      group,
+    ])) {
       addParsedDep(dep, devDependencies, skipped);
     }
-    for (const dep of extractTomlArray(content, "dependency-groups", group)) {
+    for (const dep of readDependencyGroup(
+      group,
+      readTablePath(parsedToml, ["dependency-groups"]),
+    )) {
       addParsedDep(dep, devDependencies, skipped);
     }
   }
 
-  parsePoetryDependencySection(content, "tool.poetry.dependencies", dependencies, skipped);
-  parsePoetryDependencySection(content, "tool.poetry.dev-dependencies", devDependencies, skipped);
+  parsePoetryDependencySection(
+    readTablePath(parsedToml, ["tool", "poetry", "dependencies"]),
+    dependencies,
+    skipped,
+  );
+  parsePoetryDependencySection(
+    readTablePath(parsedToml, ["tool", "poetry", "dev-dependencies"]),
+    devDependencies,
+    skipped,
+  );
   for (const group of DEV_LIKE_GROUPS) {
     parsePoetryDependencySection(
-      content,
-      `tool.poetry.group.${group}.dependencies`,
+      readTablePath(parsedToml, ["tool", "poetry", "group", group, "dependencies"]),
       devDependencies,
       skipped,
     );
@@ -156,108 +173,149 @@ function addParsedDep(
 }
 
 function parsePoetryDependencySection(
-  content: string,
-  section: string,
+  section: TomlTable | undefined,
   map: Map<string, string>,
   skipped: SkippedPythonDependency[],
 ): void {
-  const sectionContent = extractSectionContent(content, section);
-  if (!sectionContent) return;
+  if (!section) return;
 
-  for (const rawLine of sectionContent.split("\n")) {
-    const line = rawLine.trim();
-    if (line === "" || line.startsWith("#")) continue;
-
-    const simpleMatch = line.match(/^([A-Za-z0-9._-]+)\s*=\s*["']([^"']+)["']/);
-    if (simpleMatch) {
-      const name = simpleMatch[1];
-      if (name.toLowerCase() === "python") continue;
-      map.set(name, normalizePythonVersionSpec(simpleMatch[2]));
-      continue;
-    }
-
-    const inlineTableMatch = line.match(/^([A-Za-z0-9._-]+)\s*=\s*\{(.+)\}$/);
-    if (!inlineTableMatch) continue;
-
-    const name = inlineTableMatch[1];
+  for (const [name, value] of Object.entries(section)) {
     if (name.toLowerCase() === "python") continue;
 
-    const tableBody = inlineTableMatch[2];
-    const markerMatch = tableBody.match(/markers\s*=\s*["']([^"']+)["']/);
-    if (markerMatch) {
-      skipped.push({ name, spec: line, reason: "marker" });
+    const parsed = parsePoetryDependencyValue(name, value, skipped);
+    if (parsed !== null) {
+      map.set(name, normalizePythonVersionSpec(parsed));
+    }
+  }
+}
+
+function parsePoetryDependencyValue(
+  name: string,
+  value: TomlValue,
+  skipped: SkippedPythonDependency[],
+): string | null {
+  if (typeof value === "string") return value;
+
+  if (isTomlTable(value)) {
+    if (hasPoetryMarker(value)) {
+      skipped.push({ name, spec: renderPoetryDependencySpec(name, value), reason: "marker" });
+      return null;
+    }
+
+    const version = readStringPath(value, ["version"]);
+    return version ?? null;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.some((entry) => isTomlTable(entry) && hasPoetryMarker(entry))) {
+      skipped.push({ name, spec: renderPoetryDependencySpec(name, value), reason: "marker" });
+      return null;
+    }
+
+    if (value.some((entry) => typeof entry === "string" || hasPoetryVersion(entry))) {
+      return "";
+    }
+  }
+
+  return null;
+}
+
+function safeParseToml(content: string): TomlTable | undefined {
+  try {
+    return parseToml(content);
+  } catch {
+    return undefined;
+  }
+}
+
+function readDependencyGroup(
+  group: string,
+  dependencyGroups: TomlTable | undefined,
+  seen = new Set<string>(),
+): string[] {
+  if (!dependencyGroups || seen.has(group)) return [];
+
+  seen.add(group);
+
+  const value = dependencyGroups[group];
+  if (!Array.isArray(value)) return [];
+
+  const resolved: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      resolved.push(entry);
       continue;
     }
 
-    const versionMatch = tableBody.match(/version\s*=\s*["']([^"']+)["']/);
-    if (versionMatch) {
-      map.set(name, normalizePythonVersionSpec(versionMatch[1]));
+    if (!isTomlTable(entry)) continue;
+
+    const includedGroup = readStringPath(entry, ["include-group"]);
+    if (includedGroup) {
+      resolved.push(...readDependencyGroup(includedGroup, dependencyGroups, seen));
     }
   }
+
+  return resolved;
 }
 
-function extractSectionContent(content: string, section: string): string | null {
-  const sectionPattern = new RegExp(`^\\[${escapeRegex(section)}\\]\\s*$`, "m");
-  const sectionMatch = sectionPattern.exec(content);
-  if (!sectionMatch) return null;
-
-  const afterSection = content.slice(sectionMatch.index + sectionMatch[0].length);
-  const nextSectionMatch = afterSection.match(/^\[/m);
-  return nextSectionMatch ? afterSection.slice(0, nextSectionMatch.index) : afterSection;
-}
-
-/**
- * Extract a simple string field from a TOML section.
- */
-function extractStringField(content: string, section: string, field: string): string | null {
-  const sectionContent = extractSectionContent(content, section);
-  if (!sectionContent) return null;
-
-  const fieldPattern = new RegExp(`^${escapeRegex(field)}\\s*=\\s*["']([^"']*)["']`, "m");
-  const fieldMatch = fieldPattern.exec(sectionContent);
-  return fieldMatch ? fieldMatch[1] : null;
-}
-
-/**
- * Extract an array value from a TOML section.
- */
-function extractTomlArray(content: string, section: string, field: string): string[] {
-  const sectionContent = extractSectionContent(content, section);
-  if (!sectionContent) return [];
-
-  const fieldStart = new RegExp(`^${escapeRegex(field)}\\s*=\\s*\\[`, "m");
-  const fieldMatch = fieldStart.exec(sectionContent);
-  if (!fieldMatch) return [];
-
-  const bracketStart = fieldMatch.index + fieldMatch[0].length;
-  const remaining = sectionContent.slice(bracketStart);
-
-  let closingBracket = -1;
-  let inString = false;
-  let stringChar = "";
-  for (let i = 0; i < remaining.length; i++) {
-    const ch = remaining[i];
-    if (inString) {
-      if (ch === stringChar) inString = false;
-    } else if (ch === '"' || ch === "'") {
-      inString = true;
-      stringChar = ch;
-    } else if (ch === "]") {
-      closingBracket = i;
-      break;
-    }
-  }
-  if (closingBracket === -1) return [];
-
-  const arrayContent = remaining.slice(0, closingBracket);
-  const items: string[] = [];
-  const stringPattern = /["']([^"']*)["']/g;
-  for (const match of arrayContent.matchAll(stringPattern)) {
-    const value = match[1].trim();
-    if (value !== "") items.push(value);
+function readValuePath(root: TomlTable | undefined, path: string[]): TomlValue | undefined {
+  let current: TomlValue | undefined = root;
+  for (const segment of path) {
+    if (!isTomlTable(current)) return undefined;
+    current = current[segment];
   }
 
-  return items;
+  return current;
+}
+
+function readStringPath(root: TomlTable | undefined, path: string[]): string | undefined {
+  const value = readValuePath(root, path);
+  return typeof value === "string" ? value : undefined;
+}
+
+function readStringArrayPath(root: TomlTable | undefined, path: string[]): string[] {
+  const value = readValuePath(root, path);
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function readTablePath(root: TomlTable | undefined, path: string[]): TomlTable | undefined {
+  const value = readValuePath(root, path);
+  return isTomlTable(value) ? value : undefined;
+}
+
+function hasPoetryMarker(value: TomlTable): boolean {
+  return typeof value.markers === "string";
+}
+
+function hasPoetryVersion(value: TomlValue): boolean {
+  return isTomlTable(value) && typeof value.version === "string";
+}
+
+function renderPoetryDependencySpec(name: string, value: TomlValue): string {
+  return `${name} = ${renderTomlValue(value)}`;
+}
+
+function renderTomlValue(value: TomlValue): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => renderTomlValue(entry)).join(", ")}]`;
+  }
+  if (isTomlTable(value)) {
+    return `{ ${Object.entries(value)
+      .map(([key, entry]) => `${key} = ${renderTomlValue(entry)}`)
+      .join(", ")} }`;
+  }
+
+  return String(value);
+}
+
+function isTomlTable(value: TomlValue | undefined): value is TomlTable {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function collectBestEffortDependencies(packages: Map<string, string>): string[] {
@@ -277,8 +335,4 @@ function normalizePythonVersionSpec(versionSpec: string): string {
   const trimmed = versionSpec.trim();
   const pinnedMatch = trimmed.match(/^==\s*(.+)$/);
   return pinnedMatch ? pinnedMatch[1].trim() : trimmed;
-}
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/core/lockfile/python-parser.test.ts
+++ b/test/core/lockfile/python-parser.test.ts
@@ -173,6 +173,25 @@ docs = ["mkdocs==1.6.0"]
       expect(result.devDependencies.get("mkdocs")).toBe("1.6.0");
     });
 
+    it("follows include-group references inside dependency-groups", () => {
+      const result = parsePyprojectManifest(`
+[project]
+name = "dep-groups-include"
+version = "1.0.0"
+dependencies = ["requests>=2.31"]
+
+[dependency-groups]
+docs = ["mkdocs>=1.6.0", { include-group = "typing" }]
+typing = ["mypy>=1.11.0"]
+qa = ["bandit>=1.8.0"]
+`);
+
+      expect(result.dependencies.get("requests")).toBe(">=2.31");
+      expect(result.devDependencies.get("mkdocs")).toBe(">=1.6.0");
+      expect(result.devDependencies.get("mypy")).toBe(">=1.11.0");
+      expect(result.devDependencies.has("bandit")).toBe(false);
+    });
+
     it("parses Poetry dependencies and groups", () => {
       const result = parsePyprojectManifest(`
 [tool.poetry]
@@ -223,6 +242,28 @@ black = "25.1.0"
       expect(result.dependencies.get("fastapi")).toBe("^0.116.0");
       expect(result.devDependencies.get("pytest")).toBe("^8.4.0");
       expect(result.devDependencies.get("black")).toBe("25.1.0");
+    });
+
+    it("treats Poetry multi-constraint arrays as best-effort dependencies", () => {
+      const result = parsePyprojectManifest(`
+[tool.poetry]
+name = "poetry-constraints"
+version = "1.0.0"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+httpx = { version = "^0.28.1", extras = ["http2"] }
+pydantic = [
+  { version = "<2", python = "<3.12" },
+  { version = "^2.8", python = ">=3.12" },
+]
+internal-lib = { path = "../internal-lib", develop = true }
+`);
+
+      expect(result.dependencies.get("httpx")).toBe("^0.28.1");
+      expect(result.dependencies.get("pydantic")).toBe("");
+      expect(result.dependencies.has("internal-lib")).toBe(false);
+      expect(result.bestEffortDependencies).toContain("pydantic");
     });
 
     it("does not mark four-part pinned versions as best-effort", () => {

--- a/test/fixtures/python/realistic-pyproject.toml
+++ b/test/fixtures/python/realistic-pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "realistic-app"
+version = "0.2.0"
+dependencies = [
+  "httpx>=0.27",
+  "sqlalchemy>=2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.3",
+  "coverage[toml]>=7.6",
+]
+lint = [
+  "ruff==0.12.0",
+]
+ci = [
+  "pre-commit>=4.0",
+]
+
+[dependency-groups]
+docs = [
+  "mkdocs-material>=9.5",
+  { include-group = "typing" },
+]
+typing = [
+  "mypy>=1.11",
+]
+qa = [
+  "bandit>=1.8",
+]
+
+[tool.ruff]
+line-length = 100

--- a/test/integration/python-pipeline.test.ts
+++ b/test/integration/python-pipeline.test.ts
@@ -156,6 +156,31 @@ describe("Python parsing: Black pyproject.toml (extras syntax)", () => {
   });
 });
 
+describe("Python parsing: realistic pyproject.toml (mixed sections)", () => {
+  const content = loadText("realistic-pyproject.toml");
+  const parsed = parsePyprojectDependencies(content);
+
+  it("extracts project metadata from the supported scopes", () => {
+    expect(parsed.name).toBe("realistic-app");
+    expect(parsed.version).toBe("0.2.0");
+  });
+
+  it("collects production dependencies despite unrelated sections", () => {
+    expect(parsed.dependencies.get("httpx")).toBe(">=0.27");
+    expect(parsed.dependencies.get("sqlalchemy")).toBe(">=2.0");
+  });
+
+  it("collects dev-like dependency groups, including include-group entries", () => {
+    expect(parsed.devDependencies.get("pytest")).toBe(">=8.3");
+    expect(parsed.devDependencies.get("coverage")).toBe(">=7.6");
+    expect(parsed.devDependencies.get("ruff")).toBe("0.12.0");
+    expect(parsed.devDependencies.get("mkdocs-material")).toBe(">=9.5");
+    expect(parsed.devDependencies.get("mypy")).toBe(">=1.11");
+    expect(parsed.devDependencies.has("pre-commit")).toBe(false);
+    expect(parsed.devDependencies.has("bandit")).toBe(false);
+  });
+});
+
 // ─── requirements.txt parsing tests against real OSS files ───────────
 
 describe("Python parsing: httpx requirements.txt", () => {


### PR DESCRIPTION
## Summary
- replace pyproject section regex parsing with TOML-backed scope reads
- support dependency-groups include-group and Poetry multi-constraint entries for supported scopes
- expand parser coverage and document the supported Python manifest subset

## Testing
- pnpm vitest test/core/lockfile/python-parser.test.ts test/integration/python-pipeline.test.ts --run
- pnpm build
- pnpm exec biome check src/core/lockfile/python-parser.ts test/core/lockfile/python-parser.test.ts test/integration/python-pipeline.test.ts README.md

## Issue
- Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Python project dependency detection to support PEP 621 optional dependencies, PEP 643 dependency groups, and Poetry-managed dependencies with recursive group resolution.

* **Documentation**
  * Updated README with comprehensive documentation of supported Python dependency sources and known limitations.

* **Tests**
  * Added test coverage for dependency group inclusion and mixed Python project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->