### PR TITLE
feat: align python analysis notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ aminet can analyze Python dependencies from `requirements.txt` and `pyproject.to
 **Limitations:**
 - **Pinned versions (`==`) are scanned accurately.** Range specifiers resolve to the latest compatible version from PyPI, which may not match your actual environment. These are marked as best-effort in the analysis.
 - Dependencies with environment markers (e.g., `; python_version < '3.8'`) are skipped with a warning.
+- `requirements.txt` directives such as `-r`, `-e`, and `--index-url` are ignored and surfaced as analysis notes instead of being treated as package dependencies.
 - Python lockfiles are currently `analyze` inputs, not standalone `review` inputs.
 - `review` supports `requirements.txt` and `pyproject.toml`. When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
 

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -13,6 +13,7 @@ import type { DependencyGraph } from "../../core/graph/types.js";
 import { checkDenyList } from "../../core/license/deny-list.js";
 import { getLicenseAlternatives } from "../../core/license/spdx.js";
 import { parseLockfile, tryParseLockfile } from "../../core/lockfile/parser.js";
+import { buildPythonManifestNotes } from "../../core/lockfile/python-notes.js";
 import {
   parsePyprojectManifest,
   parseRequirementsManifest,
@@ -314,11 +315,11 @@ async function analyzePythonFile(
         deps.set(name, ver);
       }
     }
-    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
   } else if (fileBaseName === "requirements.txt") {
     const parsed = parseRequirementsManifest(content);
     deps = new Map(parsed.dependencies);
-    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
   } else if (
     fileBaseName === "poetry.lock" ||
     fileBaseName === "pdm.lock" ||
@@ -344,7 +345,7 @@ async function analyzePythonFile(
         deps.set(name, ver);
       }
     }
-    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
   } else {
     deps = parseRequirementsTxt(content);
   }
@@ -755,31 +756,6 @@ function writeGitHubSummary(report: Report): void {
   } catch {
     // Non-critical
   }
-}
-
-function buildPythonAnalysisNotes(
-  skipped: Array<{ name?: string; spec: string; reason: "directive" | "marker" }>,
-  bestEffortDependencies: string[],
-): string[] {
-  const notes: string[] = [];
-  const markerSkipped = skipped.filter((entry) => entry.reason === "marker");
-
-  if (bestEffortDependencies.length > 0) {
-    notes.push(
-      `Best-effort resolution was used for: ${bestEffortDependencies.join(", ")}. Unpinned Python specs resolve against the latest compatible PyPI release and may not match the exact environment.`,
-    );
-  }
-
-  if (markerSkipped.length > 0) {
-    const names = markerSkipped
-      .map((entry) => entry.name ?? entry.spec)
-      .filter((value, index, all) => all.indexOf(value) === index);
-    notes.push(
-      `Skipped marker-gated Python dependencies: ${names.join(", ")}. Environment-specific requirements are not resolved in file-based analysis.`,
-    );
-  }
-
-  return notes;
 }
 
 function parsePackageSpec(spec: string): {

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -6,6 +6,7 @@ import { buildReportForPackageSpec } from "../../core/analyzer.js";
 import { loadConfig } from "../../core/config/loader.js";
 import type { DependencyDiff } from "../../core/diff/types.js";
 import { parseLockfile } from "../../core/lockfile/parser.js";
+import { buildPythonManifestNotes } from "../../core/lockfile/python-notes.js";
 import {
   type ParsedPythonManifest,
   parsePyprojectManifest,
@@ -294,31 +295,10 @@ export function buildPythonReviewNotes(
   parsed: ParsedPythonManifest,
   includeDev: boolean | undefined,
 ): string[] {
-  const notes: string[] = [];
-
-  if (parsed.bestEffortDependencies.length > 0) {
-    notes.push(
-      `Best-effort resolution was used for: ${parsed.bestEffortDependencies.join(", ")}. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.`,
-    );
-  }
-
-  const markerSkipped = parsed.skipped.filter((entry) => entry.reason === "marker");
-  if (markerSkipped.length > 0) {
-    const names = markerSkipped
-      .map((entry) => entry.name ?? entry.spec)
-      .filter((value, index, all) => all.indexOf(value) === index);
-    notes.push(
-      `Skipped marker-gated Python dependencies: ${names.join(", ")}. Environment-specific requirements are not resolved in review mode.`,
-    );
-  }
-
-  if (includeDev && parsed.devDependencies.size > 0) {
-    notes.push(
-      `Included ${parsed.devDependencies.size} Python optional/dev dependencies in review mode.`,
-    );
-  }
-
-  return notes;
+  return buildPythonManifestNotes(parsed, {
+    includeDev,
+    mode: "review",
+  });
 }
 
 async function loadFileAtRefOrPath(filePath: string, ref?: string): Promise<string> {

--- a/src/core/lockfile/python-notes.ts
+++ b/src/core/lockfile/python-notes.ts
@@ -1,0 +1,59 @@
+import type { ParsedPythonManifest, SkippedPythonDependency } from "./python-parser.js";
+
+interface BuildPythonManifestNotesOptions {
+  includeDev?: boolean;
+  mode: "analyze" | "review";
+}
+
+export function buildPythonManifestNotes(
+  parsed: ParsedPythonManifest,
+  options: BuildPythonManifestNotesOptions,
+): string[] {
+  const notes: string[] = [];
+
+  if (parsed.bestEffortDependencies.length > 0) {
+    notes.push(
+      `Best-effort Python resolution: ${formatList(parsed.bestEffortDependencies)}. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.`,
+    );
+  }
+
+  const markerSkipped = summarizeSkipped(parsed.skipped, "marker");
+  if (markerSkipped.length > 0) {
+    notes.push(
+      `Skipped marker-gated Python dependencies: ${formatList(markerSkipped)}. Environment-specific requirements are not evaluated.`,
+    );
+  }
+
+  const directiveSkipped = summarizeSkipped(parsed.skipped, "directive");
+  if (directiveSkipped.length > 0) {
+    notes.push(
+      `Ignored requirements.txt directives: ${formatList(directiveSkipped)}. Only direct package specifiers are analyzed.`,
+    );
+  }
+
+  if (options.mode === "review" && options.includeDev && parsed.devDependencies.size > 0) {
+    notes.push(
+      `Included ${parsed.devDependencies.size} Python optional/dev dependencies in review mode.`,
+    );
+  }
+
+  return notes;
+}
+
+function summarizeSkipped(
+  skipped: SkippedPythonDependency[],
+  reason: SkippedPythonDependency["reason"],
+): string[] {
+  return skipped
+    .filter((entry) => entry.reason === reason)
+    .map((entry) => entry.name ?? entry.spec)
+    .filter((value, index, all) => all.indexOf(value) === index);
+}
+
+function formatList(values: string[]): string {
+  if (values.length <= 3) {
+    return values.join(", ");
+  }
+
+  return `${values.slice(0, 3).join(", ")} (+${values.length - 3} more)`;
+}

--- a/test/cli/commands/review.test.ts
+++ b/test/cli/commands/review.test.ts
@@ -164,17 +164,20 @@ describe("python review manifest helpers", () => {
   it("builds review notes for requirements.txt manifests", () => {
     const parsed = parsePythonReviewManifest(
       "requirements.txt",
-      'requests==2.31.0\nfastapi>=0.116 ; python_version >= "3.10"\nurllib3\n',
+      '-r base.txt\nrequests==2.31.0\nfastapi>=0.116 ; python_version >= "3.10"\nurllib3\n',
       false,
     );
 
     expect(parsed.dependencies.get("requests")).toBe("2.31.0");
     expect(parsed.dependencies.get("urllib3")).toBe("");
     expect(parsed.notes).toContain(
-      "Best-effort resolution was used for: urllib3. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.",
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
     );
     expect(parsed.notes).toContain(
-      "Skipped marker-gated Python dependencies: fastapi. Environment-specific requirements are not resolved in review mode.",
+      "Skipped marker-gated Python dependencies: fastapi. Environment-specific requirements are not evaluated.",
+    );
+    expect(parsed.notes).toContain(
+      "Ignored requirements.txt directives: -r base.txt. Only direct package specifiers are analyzed.",
     );
   });
 
@@ -218,8 +221,8 @@ dev = ["pytest>=8.0"]
     );
 
     expect(notes).toEqual([
-      "Best-effort resolution was used for: urllib3. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.",
-      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not resolved in review mode.",
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
       "Included 1 Python optional/dev dependencies in review mode.",
     ]);
   });

--- a/test/cli/output/markdown.test.ts
+++ b/test/cli/output/markdown.test.ts
@@ -190,13 +190,13 @@ describe("renderMarkdownComment", () => {
   it("renders analysis notes when present", () => {
     const diff = makeEmptyDiff();
     diff.notes = [
-      "Best-effort resolution was used for: fastapi.",
+      "Best-effort Python resolution: fastapi.",
       "Skipped marker-gated Python dependencies: typing-extensions.",
     ];
 
     const md = renderMarkdownComment(diff);
     expect(md).toContain("### Analysis Notes");
-    expect(md).toContain("Best-effort resolution was used for: fastapi.");
+    expect(md).toContain("Best-effort Python resolution: fastapi.");
     expect(md).toContain("Skipped marker-gated Python dependencies: typing-extensions.");
   });
 

--- a/test/core/lockfile/python-notes.test.ts
+++ b/test/core/lockfile/python-notes.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildPythonManifestNotes } from "../../../src/core/lockfile/python-notes.js";
+
+describe("buildPythonManifestNotes", () => {
+  it("formats aligned analyze notes for best-effort, marker skips, and directives", () => {
+    const notes = buildPythonManifestNotes(
+      {
+        name: "demo",
+        version: "1.0.0",
+        dependencies: new Map([["urllib3", ""]]),
+        devDependencies: new Map(),
+        skipped: [
+          {
+            name: "typing-extensions",
+            spec: 'typing-extensions; python_version < "3.11"',
+            reason: "marker",
+          },
+          { spec: "-r base.txt", reason: "directive" },
+          { spec: "-e .", reason: "directive" },
+        ],
+        bestEffortDependencies: ["urllib3"],
+      },
+      { mode: "analyze" },
+    );
+
+    expect(notes).toEqual([
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
+      "Ignored requirements.txt directives: -r base.txt, -e .. Only direct package specifiers are analyzed.",
+    ]);
+  });
+
+  it("caps long note lists and keeps review-specific dev messaging last", () => {
+    const notes = buildPythonManifestNotes(
+      {
+        name: "demo",
+        version: "1.0.0",
+        dependencies: new Map(),
+        devDependencies: new Map([
+          ["pytest", ">=8.0"],
+          ["ruff", "0.12.0"],
+        ]),
+        skipped: [
+          { spec: "-r base.txt", reason: "directive" },
+          { spec: "-e .", reason: "directive" },
+          { spec: "--index-url https://example.invalid/simple", reason: "directive" },
+          { spec: "--extra-index-url https://example.invalid/extra", reason: "directive" },
+        ],
+        bestEffortDependencies: ["urllib3", "httpx", "fastapi", "pydantic"],
+      },
+      { includeDev: true, mode: "review" },
+    );
+
+    expect(notes).toEqual([
+      "Best-effort Python resolution: urllib3, httpx, fastapi (+1 more). Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+      "Ignored requirements.txt directives: -r base.txt, -e ., --index-url https://example.invalid/simple (+1 more). Only direct package specifiers are analyzed.",
+      "Included 2 Python optional/dev dependencies in review mode.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize Python manifest note generation for analyze and review
- make best-effort, marker-skip, and requirements directive messaging consistent and concise
- cover the shared note builder and refresh review/markdown expectations

## Testing
- pnpm install --frozen-lockfile
- pnpm vitest test/core/lockfile/python-notes.test.ts test/cli/commands/review.test.ts test/cli/output/markdown.test.ts --run
- pnpm build
- pnpm exec biome check src/core/lockfile/python-notes.ts src/cli/commands/analyze.ts src/cli/commands/review.ts test/core/lockfile/python-notes.test.ts test/cli/commands/review.test.ts test/cli/output/markdown.test.ts

## Issue
- Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `requirements.txt` directives (`-r`, `-e`, `--index-url`) are now properly reported as analysis notes instead of being silently ignored.

* **Documentation**
  * Updated README to document that `requirements.txt` directives are emitted as analysis notes rather than interpreted as dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->