### PR TITLE
feat: improve private registry init flow

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -22,6 +22,8 @@ interface ConfigField {
   invalidMessage?: string;
 }
 
+export type PrivateRegistryMode = "auth" | "exclude" | "both" | "none";
+
 const VULN_THRESHOLDS = new Set(["low", "medium", "high", "critical"]);
 const LICENSE_THRESHOLDS = new Set(["copyleft", "weak-copyleft"]);
 
@@ -140,6 +142,77 @@ export function normalizeThresholdInput(
   return allowed.has(normalized) ? normalized : null;
 }
 
+export function parsePrivateRegistryModeInput(
+  input: string,
+  fallback: PrivateRegistryMode,
+): PrivateRegistryMode | null {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed === "") return fallback;
+  if (trimmed === "a" || trimmed === "auth") return "auth";
+  if (trimmed === "e" || trimmed === "exclude") return "exclude";
+  if (trimmed === "b" || trimmed === "both") return "both";
+  if (trimmed === "n" || trimmed === "none") return "none";
+  return null;
+}
+
+export function shouldPromptForExcludePackages(mode: PrivateRegistryMode): boolean {
+  return mode === "exclude" || mode === "both";
+}
+
+export function resolvePrivateRegistryMode(
+  selectedMode: PrivateRegistryMode,
+  config: AmiConfig,
+): PrivateRegistryMode {
+  const hasExcludePackages = Boolean(config.excludePackages && config.excludePackages.length > 0);
+
+  if (selectedMode === "both") {
+    return hasExcludePackages ? "both" : "auth";
+  }
+  if (selectedMode === "exclude") {
+    return hasExcludePackages ? "exclude" : "none";
+  }
+  if (selectedMode === "auth" && hasExcludePackages) {
+    return "both";
+  }
+  if (selectedMode === "none" && hasExcludePackages) {
+    return "exclude";
+  }
+
+  return selectedMode;
+}
+
+export function buildPrivateRegistryGuidance(
+  config: AmiConfig,
+  mode: PrivateRegistryMode,
+): string[] {
+  const lines = ["Private registry guidance:"];
+
+  if (mode === "auth" || mode === "both") {
+    lines.push(
+      `- Set ${chalk.bold("NPM_TOKEN")} in the environment when private packages should be analyzed.`,
+    );
+  }
+
+  if (mode === "exclude" || mode === "both") {
+    lines.push(
+      `- Use ${chalk.bold("excludePackages")} when internal packages should be skipped instead.`,
+    );
+  }
+
+  if (mode === "none") {
+    lines.push("- No private package handling is configured yet.");
+    lines.push(
+      `- Use ${chalk.bold("NPM_TOKEN")} for authenticated private registries, or ${chalk.bold("excludePackages")} to skip internal packages later.`,
+    );
+  }
+
+  if (config.excludePackages && config.excludePackages.length > 0) {
+    lines.push(`- Current exclude patterns: ${config.excludePackages.join(", ")}`);
+  }
+
+  return lines;
+}
+
 function formatConfig(config: AmiConfig, redactSecrets = true): string {
   // Remove fields with empty arrays or undefined values for cleaner output
   const clean: Record<string, unknown> = {};
@@ -204,7 +277,7 @@ function handleNonInteractive(configPath: string, exists: boolean, options: Init
 
   writeFileSync(configPath, `${serializeConfig(config)}\n`, "utf-8");
   console.log(formatConfig(config));
-  printPrivateRegistryGuidance(config);
+  printPrivateRegistryGuidance(config, "", resolvePrivateRegistryMode("none", config));
 }
 
 async function handleInteractive(configPath: string, exists: boolean): Promise<void> {
@@ -246,8 +319,13 @@ async function handleInteractive(configPath: string, exists: boolean): Promise<v
     }
 
     const config: AmiConfig = {};
+    const privateRegistryMode = await promptPrivateRegistryMode(rl, existingConfig);
 
     for (const field of CONFIG_FIELDS) {
+      if (field.key === "excludePackages" && !shouldPromptForExcludePackages(privateRegistryMode)) {
+        continue;
+      }
+
       const promptDefault = existingConfig?.[field.key] ?? field.defaultValue;
       const defaultStr = promptDefault === undefined ? "" : formatDefaultHint(promptDefault);
       const hint = field.hint ? chalk.dim(` (${field.hint})`) : "";
@@ -315,6 +393,7 @@ async function handleInteractive(configPath: string, exists: boolean): Promise<v
     }
 
     const finalConfig = existingConfig ? mergeConfigs(config, existingConfig) : config;
+    const finalPrivateRegistryMode = resolvePrivateRegistryMode(privateRegistryMode, finalConfig);
 
     console.log(chalk.bold("\n  Generated config:\n"));
     console.log(formatConfig(finalConfig));
@@ -327,23 +406,42 @@ async function handleInteractive(configPath: string, exists: boolean): Promise<v
 
     writeFileSync(configPath, `${serializeConfig(finalConfig)}\n`, "utf-8");
     console.log(chalk.green(`\n  Wrote ${CONFIG_FILENAME}`));
-    printPrivateRegistryGuidance(finalConfig, "  ");
+    printPrivateRegistryGuidance(finalConfig, "  ", finalPrivateRegistryMode);
   } finally {
     rl.close();
   }
 }
 
-function printPrivateRegistryGuidance(config: AmiConfig, indent = ""): void {
-  const prefix = indent ? `\n${indent}` : "\n";
-  const lines = [
-    `${prefix}Private registry guidance:`,
-    `${indent}- Set ${chalk.bold("NPM_TOKEN")} in the environment when private packages should be analyzed.`,
-    `${indent}- Use ${chalk.bold("excludePackages")} when internal packages should be skipped instead.`,
-  ];
+async function promptPrivateRegistryMode(
+  rl: ReturnType<typeof createInterface>,
+  existingConfig?: AmiConfig,
+): Promise<PrivateRegistryMode> {
+  const fallback: PrivateRegistryMode =
+    existingConfig?.excludePackages && existingConfig.excludePackages.length > 0
+      ? "exclude"
+      : "none";
 
-  if (config.excludePackages && config.excludePackages.length > 0) {
-    lines.push(`${indent}- Current exclude patterns: ${config.excludePackages.join(", ")}`);
+  while (true) {
+    const answer = await rl.question(
+      "  Private registry handling: (a)uth / (e)xclude / (b)oth / (n)either? " +
+        chalk.dim(`[${fallback}]`) +
+        ": ",
+    );
+    const parsed = parsePrivateRegistryModeInput(answer, fallback);
+    if (parsed !== null) {
+      return parsed;
+    }
+    console.log(chalk.yellow("  Enter auth, exclude, both, or none (a/e/b/n)."));
   }
+}
 
-  console.log(chalk.dim(lines.join("\n")));
+function printPrivateRegistryGuidance(
+  config: AmiConfig,
+  indent = "",
+  mode: PrivateRegistryMode = "none",
+): void {
+  const prefix = indent ? `\n${indent}` : "\n";
+  const lines = buildPrivateRegistryGuidance(config, mode).map((line) => `${indent}${line}`);
+
+  console.log(chalk.dim(`${prefix}${lines.join("\n")}`));
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -229,6 +229,23 @@ export function buildPrivateRegistryGuidance(
   return lines;
 }
 
+export function applyPrivateRegistryModeSelection(
+  config: AmiConfig,
+  mode: PrivateRegistryMode,
+): AmiConfig {
+  const next: AmiConfig = { ...config };
+
+  if (mode === "auth" || mode === "none") {
+    next.excludePackages = [];
+  }
+
+  if (mode === "exclude" || mode === "none") {
+    delete next.npmToken;
+  }
+
+  return next;
+}
+
 function formatConfig(config: AmiConfig, redactSecrets = true): string {
   // Remove fields with empty arrays or undefined values for cleaner output
   const clean: Record<string, unknown> = {};
@@ -336,9 +353,6 @@ async function handleInteractive(configPath: string, exists: boolean): Promise<v
 
     const config: AmiConfig = {};
     const privateRegistryMode = await promptPrivateRegistryMode(rl, existingConfig);
-    if (!shouldPromptForExcludePackages(privateRegistryMode)) {
-      config.excludePackages = [];
-    }
 
     for (const field of CONFIG_FIELDS) {
       if (field.key === "excludePackages" && !shouldPromptForExcludePackages(privateRegistryMode)) {
@@ -411,7 +425,8 @@ async function handleInteractive(configPath: string, exists: boolean): Promise<v
       }
     }
 
-    const finalConfig = existingConfig ? mergeConfigs(config, existingConfig) : config;
+    const mergedConfig = existingConfig ? mergeConfigs(config, existingConfig) : config;
+    const finalConfig = applyPrivateRegistryModeSelection(mergedConfig, privateRegistryMode);
     const finalPrivateRegistryMode = resolvePrivateRegistryMode(privateRegistryMode, finalConfig);
 
     console.log(chalk.bold("\n  Generated config:\n"));

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -159,26 +159,46 @@ export function shouldPromptForExcludePackages(mode: PrivateRegistryMode): boole
   return mode === "exclude" || mode === "both";
 }
 
+export function getPrivateRegistryModeFallback(existingConfig?: AmiConfig): PrivateRegistryMode {
+  const hasExcludePackages = Boolean(
+    existingConfig?.excludePackages && existingConfig.excludePackages.length > 0,
+  );
+  const hasConfiguredAuth =
+    typeof existingConfig?.npmToken === "string" && existingConfig.npmToken.trim().length > 0;
+
+  if (hasConfiguredAuth && hasExcludePackages) {
+    return "both";
+  }
+  if (hasConfiguredAuth) {
+    return "auth";
+  }
+  if (hasExcludePackages) {
+    return "exclude";
+  }
+
+  return "none";
+}
+
 export function resolvePrivateRegistryMode(
   selectedMode: PrivateRegistryMode,
   config: AmiConfig,
 ): PrivateRegistryMode {
   const hasExcludePackages = Boolean(config.excludePackages && config.excludePackages.length > 0);
+  const hasConfiguredAuth =
+    typeof config.npmToken === "string" && config.npmToken.trim().length > 0;
+  const hasAuth = selectedMode === "auth" || selectedMode === "both" || hasConfiguredAuth;
 
-  if (selectedMode === "both") {
-    return hasExcludePackages ? "both" : "auth";
-  }
-  if (selectedMode === "exclude") {
-    return hasExcludePackages ? "exclude" : "none";
-  }
-  if (selectedMode === "auth" && hasExcludePackages) {
+  if (hasAuth && hasExcludePackages) {
     return "both";
   }
-  if (selectedMode === "none" && hasExcludePackages) {
+  if (hasAuth) {
+    return "auth";
+  }
+  if (hasExcludePackages) {
     return "exclude";
   }
 
-  return selectedMode;
+  return "none";
 }
 
 export function buildPrivateRegistryGuidance(
@@ -188,21 +208,17 @@ export function buildPrivateRegistryGuidance(
   const lines = ["Private registry guidance:"];
 
   if (mode === "auth" || mode === "both") {
-    lines.push(
-      `- Set ${chalk.bold("NPM_TOKEN")} in the environment when private packages should be analyzed.`,
-    );
+    lines.push("- Set NPM_TOKEN in the environment when private packages should be analyzed.");
   }
 
   if (mode === "exclude" || mode === "both") {
-    lines.push(
-      `- Use ${chalk.bold("excludePackages")} when internal packages should be skipped instead.`,
-    );
+    lines.push("- Use excludePackages when internal packages should be skipped instead.");
   }
 
   if (mode === "none") {
     lines.push("- No private package handling is configured yet.");
     lines.push(
-      `- Use ${chalk.bold("NPM_TOKEN")} for authenticated private registries, or ${chalk.bold("excludePackages")} to skip internal packages later.`,
+      "- Use NPM_TOKEN for authenticated private registries, or excludePackages to skip internal packages later.",
     );
   }
 
@@ -320,6 +336,9 @@ async function handleInteractive(configPath: string, exists: boolean): Promise<v
 
     const config: AmiConfig = {};
     const privateRegistryMode = await promptPrivateRegistryMode(rl, existingConfig);
+    if (!shouldPromptForExcludePackages(privateRegistryMode)) {
+      config.excludePackages = [];
+    }
 
     for (const field of CONFIG_FIELDS) {
       if (field.key === "excludePackages" && !shouldPromptForExcludePackages(privateRegistryMode)) {
@@ -416,10 +435,7 @@ async function promptPrivateRegistryMode(
   rl: ReturnType<typeof createInterface>,
   existingConfig?: AmiConfig,
 ): Promise<PrivateRegistryMode> {
-  const fallback: PrivateRegistryMode =
-    existingConfig?.excludePackages && existingConfig.excludePackages.length > 0
-      ? "exclude"
-      : "none";
+  const fallback = getPrivateRegistryModeFallback(existingConfig);
 
   while (true) {
     const answer = await rl.question(
@@ -440,8 +456,15 @@ function printPrivateRegistryGuidance(
   indent = "",
   mode: PrivateRegistryMode = "none",
 ): void {
-  const prefix = indent ? `\n${indent}` : "\n";
-  const lines = buildPrivateRegistryGuidance(config, mode).map((line) => `${indent}${line}`);
+  const lines = buildPrivateRegistryGuidance(config, mode).map(
+    (line) => `${indent}${formatGuidanceLine(line)}`,
+  );
 
-  console.log(chalk.dim(`${prefix}${lines.join("\n")}`));
+  console.log(chalk.dim(`\n${lines.join("\n")}`));
+}
+
+function formatGuidanceLine(line: string): string {
+  return line
+    .replaceAll("NPM_TOKEN", chalk.bold("NPM_TOKEN"))
+    .replaceAll("excludePackages", chalk.bold("excludePackages"));
 }

--- a/test/cli/commands/init.test.ts
+++ b/test/cli/commands/init.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildDefaultConfig,
   buildPrivateRegistryGuidance,
+  getPrivateRegistryModeFallback,
   mergeConfigs,
   normalizeThresholdInput,
   parseBooleanInput,
@@ -120,6 +121,13 @@ describe("init command helpers", () => {
     it("resolves the effective private registry mode from the final config", () => {
       expect(resolvePrivateRegistryMode("auth", {})).toBe("auth");
       expect(resolvePrivateRegistryMode("auth", { excludePackages: ["@internal/*"] })).toBe("both");
+      expect(resolvePrivateRegistryMode("none", { npmToken: "tok_123" })).toBe("auth");
+      expect(
+        resolvePrivateRegistryMode("none", {
+          npmToken: "tok_123",
+          excludePackages: ["@internal/*"],
+        }),
+      ).toBe("both");
       expect(resolvePrivateRegistryMode("exclude", {})).toBe("none");
       expect(resolvePrivateRegistryMode("exclude", { excludePackages: ["@internal/*"] })).toBe(
         "exclude",
@@ -128,6 +136,18 @@ describe("init command helpers", () => {
       expect(resolvePrivateRegistryMode("none", { excludePackages: ["@internal/*"] })).toBe(
         "exclude",
       );
+    });
+
+    it("derives the prompt fallback from existing auth and exclude config", () => {
+      expect(getPrivateRegistryModeFallback()).toBe("none");
+      expect(getPrivateRegistryModeFallback({ excludePackages: ["@internal/*"] })).toBe("exclude");
+      expect(getPrivateRegistryModeFallback({ npmToken: "tok_123" })).toBe("auth");
+      expect(
+        getPrivateRegistryModeFallback({
+          npmToken: "tok_123",
+          excludePackages: ["@internal/*"],
+        }),
+      ).toBe("both");
     });
 
     it("builds targeted guidance without embedding secrets", () => {

--- a/test/cli/commands/init.test.ts
+++ b/test/cli/commands/init.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyPrivateRegistryModeSelection,
   buildDefaultConfig,
   buildPrivateRegistryGuidance,
   getPrivateRegistryModeFallback,
@@ -163,6 +164,36 @@ describe("init command helpers", () => {
         "- Use excludePackages when internal packages should be skipped instead.",
         "- Current exclude patterns: @internal/*",
       ]);
+    });
+
+    it("applies mode selection to merged auth and exclude settings", () => {
+      expect(
+        applyPrivateRegistryModeSelection(
+          { npmToken: "tok_123", excludePackages: ["@internal/*"] },
+          "auth",
+        ),
+      ).toEqual({
+        npmToken: "tok_123",
+        excludePackages: [],
+      });
+
+      expect(
+        applyPrivateRegistryModeSelection(
+          { npmToken: "tok_123", excludePackages: ["@internal/*"] },
+          "exclude",
+        ),
+      ).toEqual({
+        excludePackages: ["@internal/*"],
+      });
+
+      expect(
+        applyPrivateRegistryModeSelection(
+          { npmToken: "tok_123", excludePackages: ["@internal/*"] },
+          "none",
+        ),
+      ).toEqual({
+        excludePackages: [],
+      });
     });
   });
 });

--- a/test/cli/commands/init.test.ts
+++ b/test/cli/commands/init.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   buildDefaultConfig,
+  buildPrivateRegistryGuidance,
   mergeConfigs,
   normalizeThresholdInput,
   parseBooleanInput,
+  parsePrivateRegistryModeInput,
+  resolvePrivateRegistryMode,
+  shouldPromptForExcludePackages,
 } from "../../../src/cli/commands/init.js";
 
 describe("init command helpers", () => {
@@ -94,6 +98,51 @@ describe("init command helpers", () => {
     it("rejects invalid threshold values", () => {
       const allowed = new Set(["low", "medium", "high", "critical"]);
       expect(normalizeThresholdInput("hgh", allowed)).toBeNull();
+    });
+  });
+
+  describe("private registry helpers", () => {
+    it("parses private registry mode shortcuts", () => {
+      expect(parsePrivateRegistryModeInput("a", "none")).toBe("auth");
+      expect(parsePrivateRegistryModeInput("exclude", "none")).toBe("exclude");
+      expect(parsePrivateRegistryModeInput("both", "none")).toBe("both");
+      expect(parsePrivateRegistryModeInput("", "none")).toBe("none");
+      expect(parsePrivateRegistryModeInput("weird", "none")).toBeNull();
+    });
+
+    it("prompts for excludePackages only when exclusion is selected", () => {
+      expect(shouldPromptForExcludePackages("auth")).toBe(false);
+      expect(shouldPromptForExcludePackages("none")).toBe(false);
+      expect(shouldPromptForExcludePackages("exclude")).toBe(true);
+      expect(shouldPromptForExcludePackages("both")).toBe(true);
+    });
+
+    it("resolves the effective private registry mode from the final config", () => {
+      expect(resolvePrivateRegistryMode("auth", {})).toBe("auth");
+      expect(resolvePrivateRegistryMode("auth", { excludePackages: ["@internal/*"] })).toBe("both");
+      expect(resolvePrivateRegistryMode("exclude", {})).toBe("none");
+      expect(resolvePrivateRegistryMode("exclude", { excludePackages: ["@internal/*"] })).toBe(
+        "exclude",
+      );
+      expect(resolvePrivateRegistryMode("both", {})).toBe("auth");
+      expect(resolvePrivateRegistryMode("none", { excludePackages: ["@internal/*"] })).toBe(
+        "exclude",
+      );
+    });
+
+    it("builds targeted guidance without embedding secrets", () => {
+      expect(buildPrivateRegistryGuidance({}, "none")).toEqual([
+        "Private registry guidance:",
+        "- No private package handling is configured yet.",
+        "- Use NPM_TOKEN for authenticated private registries, or excludePackages to skip internal packages later.",
+      ]);
+
+      expect(buildPrivateRegistryGuidance({ excludePackages: ["@internal/*"] }, "both")).toEqual([
+        "Private registry guidance:",
+        "- Set NPM_TOKEN in the environment when private packages should be analyzed.",
+        "- Use excludePackages when internal packages should be skipped instead.",
+        "- Current exclude patterns: @internal/*",
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add explicit private registry setup modes to aminet init
- only prompt for excludePackages when exclusion is part of the selected setup
- tailor post-write guidance without writing private auth tokens into config

## Testing
- pnpm install --frozen-lockfile
- pnpm vitest test/cli/commands/init.test.ts --run
- pnpm build
- pnpm exec biome check src/cli/commands/init.ts test/cli/commands/init.test.ts

## Issue
- Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced initialization workflow now includes configurable private registry handling.
  * Interactive init prompts users to select their preferred private registry strategy: authentication, package exclusion, both, or neither.
  * Configuration guidance is now context-aware and adapts based on the selected private registry handling mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->