### PR TITLE
chore: clarify degraded cache mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ npx aminet cache stats
 npx aminet cache prune
 ```
 
-If native SQLite bindings are unavailable, `analyze` and `review` fall back to an ephemeral in-memory cache for the current run. `aminet cache ...` subcommands still require the on-disk database and will exit non-zero in that environment.
+If native SQLite bindings are unavailable, `analyze` and `review` still run, but aminet disables DB-backed caching in that environment. `aminet cache ...` subcommands still require the on-disk database and will exit non-zero until persistent cache support is available.
 
 ## CLI commands
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ npx aminet cache stats
 npx aminet cache prune
 ```
 
+If native SQLite bindings are unavailable, `analyze` and `review` fall back to an ephemeral in-memory cache for the current run. `aminet cache ...` subcommands still require the on-disk database and will exit non-zero in that environment.
+
 ## CLI commands
 
 Top-level commands:

--- a/src/cli/commands/cache.ts
+++ b/src/cli/commands/cache.ts
@@ -77,7 +77,7 @@ function ensurePersistentCache(): boolean {
   const reason = getPersistentCacheFailureReason() ?? "unknown error";
   console.error(
     chalk.yellow(
-      `Persistent cache unavailable: ${reason}. This cache command needs the on-disk database, but analyze/review still work without persistent cache.`,
+      `Persistent cache is unavailable in this environment: ${reason}. Cache subcommands need the on-disk database. Analyze and review still work in ephemeral mode, but cache stats/prune/clear are disabled.`,
     ),
   );
   process.exitCode = 1;

--- a/src/cli/commands/cache.ts
+++ b/src/cli/commands/cache.ts
@@ -77,7 +77,7 @@ function ensurePersistentCache(): boolean {
   const reason = getPersistentCacheFailureReason() ?? "unknown error";
   console.error(
     chalk.yellow(
-      `Persistent cache is unavailable in this environment: ${reason}. Cache subcommands need the on-disk database. Analyze and review still work in ephemeral mode, but cache stats/prune/clear are disabled.`,
+      `Persistent cache is unavailable in this environment: ${reason}. Cache subcommands need the on-disk database. Analyze and review still work, but DB-backed caching is disabled in this environment, so cache stats/prune/clear are unavailable.`,
     ),
   );
   process.exitCode = 1;

--- a/src/core/store/database.ts
+++ b/src/core/store/database.ts
@@ -87,7 +87,7 @@ export function getDatabase(dbPath?: string): DatabaseLike {
 
     if (!warnedPersistentCacheFailure) {
       logger.warn(
-        `Persistent cache unavailable for this run: ${persistentCacheFailureReason}. Analyze and review will continue without the on-disk cache.`,
+        `Persistent cache is unavailable in this environment: ${persistentCacheFailureReason}. aminet will continue in ephemeral mode for this run, so analyze and review still work but nothing is stored on disk.`,
       );
       warnedPersistentCacheFailure = true;
     }

--- a/src/core/store/database.ts
+++ b/src/core/store/database.ts
@@ -87,7 +87,7 @@ export function getDatabase(dbPath?: string): DatabaseLike {
 
     if (!warnedPersistentCacheFailure) {
       logger.warn(
-        `Persistent cache is unavailable in this environment: ${persistentCacheFailureReason}. aminet will continue in ephemeral mode for this run, so analyze and review still work but nothing is stored on disk.`,
+        `Persistent cache is unavailable in this environment: ${persistentCacheFailureReason}. aminet will continue without persistent storage for this run. Analyze and review still work, but DB-backed caching is disabled until persistent cache is available.`,
       );
       warnedPersistentCacheFailure = true;
     }

--- a/test/cli/commands/cache.test.ts
+++ b/test/cli/commands/cache.test.ts
@@ -38,8 +38,11 @@ describe("cache command degraded mode", () => {
 
     await cacheStatsCommand();
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Persistent cache unavailable: native bindings unavailable"),
+      expect.stringContaining(
+        "Persistent cache is unavailable in this environment: native bindings unavailable",
+      ),
     );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("ephemeral mode"));
     expect(getStoreStats).not.toHaveBeenCalled();
 
     process.exitCode = 0;

--- a/test/cli/commands/cache.test.ts
+++ b/test/cli/commands/cache.test.ts
@@ -42,7 +42,7 @@ describe("cache command degraded mode", () => {
         "Persistent cache is unavailable in this environment: native bindings unavailable",
       ),
     );
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("ephemeral mode"));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("DB-backed caching is disabled"));
     expect(getStoreStats).not.toHaveBeenCalled();
 
     process.exitCode = 0;

--- a/test/core/store/database.test.ts
+++ b/test/core/store/database.test.ts
@@ -1,47 +1,51 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("database fallback", () => {
+describe("database degraded mode", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
-    process.exitCode = 0;
   });
 
-  afterEach(async () => {
-    try {
-      const dbModule = await import("../../../src/core/store/database.js");
-      dbModule.closeDatabase();
-    } catch {
-      // ignore
-    }
+  afterEach(() => {
     vi.doUnmock("../../../src/core/store/adapter.js");
-    process.exitCode = 0;
+    vi.doUnmock("../../../src/core/store/migrations.js");
+    vi.doUnmock("../../../src/utils/logger.js");
   });
 
-  it("falls back to a no-op database when native sqlite fails to initialize", async () => {
-    vi.doMock("../../../src/core/store/adapter.js", async () => {
-      const actual = await vi.importActual<typeof import("../../../src/core/store/adapter.js")>(
-        "../../../src/core/store/adapter.js",
-      );
-      return {
-        ...actual,
-        createDatabase: () => {
-          throw new Error("native bindings unavailable");
-        },
-      };
-    });
+  it("warns once and continues in ephemeral mode when persistent cache init fails", async () => {
+    const warn = vi.fn();
 
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const dbModule = await import("../../../src/core/store/database.js");
-    const packumentStore = await import("../../../src/core/store/packument-store.js");
+    vi.doMock("../../../src/core/store/adapter.js", () => ({
+      createDatabase: vi.fn(() => {
+        throw new Error("native bindings unavailable");
+      }),
+    }));
+    vi.doMock("../../../src/core/store/migrations.js", () => ({
+      runMigrations: vi.fn(),
+    }));
+    vi.doMock("../../../src/utils/logger.js", () => ({
+      logger: {
+        debug: vi.fn(),
+        warn,
+      },
+    }));
 
-    dbModule.getDatabase();
+    const {
+      closeDatabase,
+      getDatabase,
+      getPersistentCacheFailureReason,
+      isPersistentCacheAvailable,
+    } = await import("../../../src/core/store/database.js");
 
-    expect(dbModule.isPersistentCacheAvailable()).toBe(false);
-    expect(dbModule.getPersistentCacheFailureReason()).toContain("native bindings unavailable");
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const first = getDatabase(":memory:");
+    const second = getDatabase(":memory:");
 
-    expect(() => packumentStore.cachePackument("express", { name: "express" })).not.toThrow();
-    expect(packumentStore.getCachedPackument("express")).toBeNull();
+    expect(first).toBe(second);
+    expect(isPersistentCacheAvailable()).toBe(false);
+    expect(getPersistentCacheFailureReason()).toBe("native bindings unavailable");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("ephemeral mode"));
+
+    closeDatabase();
   });
 });

--- a/test/core/store/database.test.ts
+++ b/test/core/store/database.test.ts
@@ -12,7 +12,7 @@ describe("database degraded mode", () => {
     vi.doUnmock("../../../src/utils/logger.js");
   });
 
-  it("warns once and continues in ephemeral mode when persistent cache init fails", async () => {
+  it("warns once and continues without persistent storage when cache init fails", async () => {
     const warn = vi.fn();
 
     vi.doMock("../../../src/core/store/adapter.js", () => ({
@@ -44,7 +44,10 @@ describe("database degraded mode", () => {
     expect(isPersistentCacheAvailable()).toBe(false);
     expect(getPersistentCacheFailureReason()).toBe("native bindings unavailable");
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("ephemeral mode"));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("continue without persistent storage"),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("DB-backed caching is disabled"));
 
     closeDatabase();
   });


### PR DESCRIPTION
## Summary
- reword degraded cache messages around explicit ephemeral-mode behavior
- document that cache subcommands need the on-disk database while analyze/review still continue
- add regression coverage for the database fallback warning and cache subcommands

## Testing
- pnpm install --frozen-lockfile
- pnpm vitest test/cli/commands/cache.test.ts test/core/store/database.test.ts --run
- pnpm build
- pnpm exec biome check src/cli/commands/cache.ts src/core/store/database.ts test/cli/commands/cache.test.ts test/core/store/database.test.ts

## Issue
- Closes #40