### PR TITLE
docs: define Python lockfile support strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,13 +382,22 @@ aminet can analyze Python dependencies from `requirements.txt` and `pyproject.to
   - Poetry `[tool.poetry.dependencies]`, `[tool.poetry.dev-dependencies]`, and `[tool.poetry.group.<name>.dependencies]`
 - `poetry.lock`, `pdm.lock`, and `uv.lock` for `analyze`
 
+| Input | `analyze` | `review` | GitHub Action |
+|-------|-----------|----------|---------------|
+| `requirements.txt` | supported | supported | supported through `path` |
+| `pyproject.toml` | supported | supported | supported through `path` |
+| `poetry.lock` | supported | not a standalone input | use through `lockfile-path` with `pyproject.toml` |
+| `pdm.lock` | supported | not a standalone input | use through `lockfile-path` with `pyproject.toml` |
+| `uv.lock` | supported | not a standalone input | use through `lockfile-path` with `pyproject.toml` |
+
 **Limitations:**
 - **Pinned versions (`==`) are scanned accurately.** Range specifiers resolve to the latest compatible version from PyPI, which may not match your actual environment. These are marked as best-effort in the analysis.
 - Dependencies with environment markers (e.g., `; python_version < '3.8'`) are skipped with a warning.
 - Poetry dependencies without a version-bearing specifier, such as local `path` or `git` sources, are currently out of scope for `pyproject.toml` parsing.
 - `requirements.txt` directives such as `-r`, `-e`, and `--index-url` are ignored and surfaced as analysis/review notes instead of being treated as package dependencies.
-- Python lockfiles are currently `analyze` inputs, not standalone `review` inputs.
+- Python lockfiles are analyze-first inputs, not standalone `review` inputs.
 - `review` supports `requirements.txt` and `pyproject.toml`. When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
+- The GitHub Action wraps `review`, so Python lockfiles are passed through `lockfile-path` instead of `path`.
 
 For the longer-term compatibility target, see [`ROADMAP.md`](./ROADMAP.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,10 +18,23 @@
 
 ## Python lockfile support strategy
 
-- `requirements.txt` and `pyproject.toml` are the primary review inputs for Python projects.
-- `poetry.lock`, `pdm.lock`, and `uv.lock` are supported for `analyze`.
-- When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
-- Python lockfiles are not first-class `review` inputs yet; the review contract remains manifest-first so the changed direct dependencies are explicit in the PR diff.
+Support matrix:
+
+| Input | `analyze` | `review` | GitHub Action |
+|-------|-----------|----------|---------------|
+| `requirements.txt` | supported | supported | supported through `path` |
+| `pyproject.toml` | supported | supported | supported through `path` |
+| `poetry.lock` | supported | not a standalone input | use through `lockfile-path` when reviewing `pyproject.toml` |
+| `pdm.lock` | supported | not a standalone input | use through `lockfile-path` when reviewing `pyproject.toml` |
+| `uv.lock` | supported | not a standalone input | use through `lockfile-path` when reviewing `pyproject.toml` |
+
+Sequencing rules:
+
+- `requirements.txt` and `pyproject.toml` remain the primary review inputs for Python projects.
+- Python lockfiles are first-class for `analyze`, because they pin direct dependency versions without depending on a Git diff.
+- Python lockfiles are not first-class `review` inputs. The review contract stays manifest-first so the changed direct dependencies remain explicit in the PR diff.
+- When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it only to pin direct dependency versions where possible.
+- The GitHub Action wraps `review`, so Python lockfiles are passed through `lockfile-path` instead of `path`.
 
 ## 1.0 release criteria
 


### PR DESCRIPTION
## Summary
- add a Python support matrix for requirements, pyproject, and poetry/pdm/uv lockfiles
- define analyze vs review vs GitHub Action expectations for Python lockfiles
- document the manifest-first sequencing rules for review

## Testing
- not run (docs-only)

## Issue
- Closes #37