### PR TITLE
refactor: share Python output note semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,12 +316,17 @@ aminet can analyze Python dependencies from `requirements.txt` and `pyproject.to
 
 **Supported input formats:**
 - `requirements.txt` with pinned (`==`) or range specifiers
-- `pyproject.toml` with PEP 621 `[project].dependencies`
+- `pyproject.toml` with these supported scopes:
+  - PEP 621 `[project].dependencies`
+  - `[project.optional-dependencies]` for dev-like groups: `dev`, `test`, `tests`, `docs`, `doc`, `lint`, `typing`, `typecheck`
+  - `[dependency-groups]` for the same dev-like groups, including `include-group`
+  - Poetry `[tool.poetry.dependencies]`, `[tool.poetry.dev-dependencies]`, and `[tool.poetry.group.<name>.dependencies]`
 - `poetry.lock`, `pdm.lock`, and `uv.lock` for `analyze`
 
 **Limitations:**
 - **Pinned versions (`==`) are scanned accurately.** Range specifiers resolve to the latest compatible version from PyPI, which may not match your actual environment. These are marked as best-effort in the analysis.
 - Dependencies with environment markers (e.g., `; python_version < '3.8'`) are skipped with a warning.
+- Poetry dependencies without a version-bearing specifier, such as local `path` or `git` sources, are currently out of scope for review parsing.
 - Python lockfiles are currently `analyze` inputs, not standalone `review` inputs.
 - `review` supports `requirements.txt` and `pyproject.toml`. When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Common inputs:
 - `exclude-packages`: comma-separated packages to skip (supports wildcards like `@scope/*`)
 - `npm-token`: npm auth token for private registry access
 
+Capability guide:
+
+| Surface | Supported inputs |
+|---------|------------------|
+| `analyze` CLI | `package.json`, `pnpm-lock.yaml`, `package-lock.json`, `bun.lock`, `requirements.txt`, `pyproject.toml`, `poetry.lock`, `pdm.lock`, `uv.lock` |
+| `review` CLI | `package.json`, `requirements.txt`, `pyproject.toml` |
+| GitHub Action | wraps `review`; use `path` with `package.json`, `requirements.txt`, or `pyproject.toml` |
+
+For Python projects, the Action does not accept standalone Python lockfiles through `path`. Use `lockfile-path` to pin a `pyproject.toml` review with `poetry.lock`, `pdm.lock`, or `uv.lock`.
+
 For monorepo usage where `package.json` is in a sub-package:
 
 ```yaml
@@ -88,6 +98,15 @@ For Python review from a manifest:
         with:
           path: pyproject.toml
           lockfile-path: uv.lock
+          security: "true"
+```
+
+For Python review from `requirements.txt`:
+
+```yaml
+      - uses: gorira-tatsu/aminet@v0.2.1
+        with:
+          path: requirements.txt
           security: "true"
 ```
 
@@ -167,6 +186,7 @@ Analyze Python dependencies:
 ```bash
 npx aminet analyze requirements.txt
 npx aminet analyze pyproject.toml
+npx aminet analyze uv.lock
 npx aminet analyze requests --ecosystem pypi
 ```
 
@@ -178,6 +198,12 @@ npx aminet review package.json --base HEAD~1 --no-dev  # exclude devDependencies
 npx aminet review requirements.txt --base HEAD~1 --security
 npx aminet review pyproject.toml --base HEAD~1 --lockfile-path uv.lock
 ```
+
+Capability summary:
+
+- `analyze` accepts standalone Python lockfiles (`poetry.lock`, `pdm.lock`, `uv.lock`) and reads the adjacent `pyproject.toml`.
+- `review` accepts `requirements.txt` and `pyproject.toml`, not standalone Python lockfiles.
+- the GitHub Action wraps `review`, so Python lockfiles are passed through `lockfile-path` rather than `path`.
 
 Review with private packages (skip or authenticate):
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ aminet can analyze Python dependencies from `requirements.txt` and `pyproject.to
 - **Pinned versions (`==`) are scanned accurately.** Range specifiers resolve to the latest compatible version from PyPI, which may not match your actual environment. These are marked as best-effort in the analysis.
 - Dependencies with environment markers (e.g., `; python_version < '3.8'`) are skipped with a warning.
 - Poetry dependencies without a version-bearing specifier, such as local `path` or `git` sources, are currently out of scope for review parsing.
+- `requirements.txt` directives such as `-r`, `-e`, and `--index-url` are ignored and surfaced as analysis notes instead of being treated as package dependencies.
 - Python lockfiles are currently `analyze` inputs, not standalone `review` inputs.
 - `review` supports `requirements.txt` and `pyproject.toml`. When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
 

--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ aminet can analyze Python dependencies from `requirements.txt` and `pyproject.to
 **Limitations:**
 - **Pinned versions (`==`) are scanned accurately.** Range specifiers resolve to the latest compatible version from PyPI, which may not match your actual environment. These are marked as best-effort in the analysis.
 - Dependencies with environment markers (e.g., `; python_version < '3.8'`) are skipped with a warning.
-- Poetry dependencies without a version-bearing specifier, such as local `path` or `git` sources, are currently out of scope for review parsing.
-- `requirements.txt` directives such as `-r`, `-e`, and `--index-url` are ignored and surfaced as analysis notes instead of being treated as package dependencies.
+- Poetry dependencies without a version-bearing specifier, such as local `path` or `git` sources, are currently out of scope for `pyproject.toml` parsing.
+- `requirements.txt` directives such as `-r`, `-e`, and `--index-url` are ignored and surfaced as analysis/review notes instead of being treated as package dependencies.
 - Python lockfiles are currently `analyze` inputs, not standalone `review` inputs.
 - `review` supports `requirements.txt` and `pyproject.toml`. When a `pyproject.toml` review has an adjacent or explicit Python lockfile, aminet uses it to pin direct dependency versions where possible.
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: red
 inputs:
   path:
-    description: "Path to the dependency manifest to review (package.json, requirements.txt, or pyproject.toml)"
+    description: "Path to the manifest to review. Supports package.json, requirements.txt, and pyproject.toml."
     default: "package.json"
   depth:
     description: "Maximum dependency depth"
@@ -20,7 +20,7 @@ inputs:
     description: "Enable security deep analysis"
     default: "true"
   lockfile-path:
-    description: "Explicit path to lockfile (for monorepos or Python lockfiles used to pin pyproject review)"
+    description: "Explicit lockfile path used to pin review resolution (monorepos, or poetry.lock / pdm.lock / uv.lock alongside pyproject.toml)"
     required: false
   dev:
     description: "Include devDependencies in review (default: true)"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "commander": "^13.1.0",
     "ora": "^8.2.0",
     "semver": "^7.7.1",
+    "smol-toml": "^1.6.1",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       semver:
         specifier: ^7.7.1
         version: 7.7.4
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
       yaml:
         specifier: ^2.8.1
         version: 2.8.2
@@ -724,6 +727,10 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1447,6 +1454,8 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -315,11 +315,15 @@ async function analyzePythonFile(
         deps.set(name, ver);
       }
     }
-    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
+    analysisNotes.push(
+      ...buildPythonManifestNotes(parsed, { includeDev: options.dev, mode: "analyze" }),
+    );
   } else if (fileBaseName === "requirements.txt") {
     const parsed = parseRequirementsManifest(content);
     deps = new Map(parsed.dependencies);
-    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
+    analysisNotes.push(
+      ...buildPythonManifestNotes(parsed, { includeDev: options.dev, mode: "analyze" }),
+    );
   } else if (
     fileBaseName === "poetry.lock" ||
     fileBaseName === "pdm.lock" ||
@@ -345,7 +349,9 @@ async function analyzePythonFile(
         deps.set(name, ver);
       }
     }
-    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
+    analysisNotes.push(
+      ...buildPythonManifestNotes(parsed, { includeDev: options.dev, mode: "analyze" }),
+    );
   } else {
     deps = parseRequirementsTxt(content);
   }

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -13,6 +13,7 @@ import type { DependencyGraph } from "../../core/graph/types.js";
 import { checkDenyList } from "../../core/license/deny-list.js";
 import { getLicenseAlternatives } from "../../core/license/spdx.js";
 import { parseLockfile, tryParseLockfile } from "../../core/lockfile/parser.js";
+import { buildPythonManifestNotes } from "../../core/lockfile/python-notes.js";
 import {
   parsePyprojectManifest,
   parseRequirementsManifest,
@@ -314,11 +315,11 @@ async function analyzePythonFile(
         deps.set(name, ver);
       }
     }
-    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
   } else if (fileBaseName === "requirements.txt") {
     const parsed = parseRequirementsManifest(content);
     deps = new Map(parsed.dependencies);
-    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
   } else if (
     fileBaseName === "poetry.lock" ||
     fileBaseName === "pdm.lock" ||
@@ -344,7 +345,7 @@ async function analyzePythonFile(
         deps.set(name, ver);
       }
     }
-    analysisNotes.push(...buildPythonAnalysisNotes(parsed.skipped, parsed.bestEffortDependencies));
+    analysisNotes.push(...buildPythonManifestNotes(parsed, { mode: "analyze" }));
   } else {
     deps = parseRequirementsTxt(content);
   }
@@ -755,31 +756,6 @@ function writeGitHubSummary(report: Report): void {
   } catch {
     // Non-critical
   }
-}
-
-function buildPythonAnalysisNotes(
-  skipped: Array<{ name?: string; spec: string; reason: "directive" | "marker" }>,
-  bestEffortDependencies: string[],
-): string[] {
-  const notes: string[] = [];
-  const markerSkipped = skipped.filter((entry) => entry.reason === "marker");
-
-  if (bestEffortDependencies.length > 0) {
-    notes.push(
-      `Best-effort resolution was used for: ${bestEffortDependencies.join(", ")}. Unpinned Python specs resolve against the latest compatible PyPI release and may not match the exact environment.`,
-    );
-  }
-
-  if (markerSkipped.length > 0) {
-    const names = markerSkipped
-      .map((entry) => entry.name ?? entry.spec)
-      .filter((value, index, all) => all.indexOf(value) === index);
-    notes.push(
-      `Skipped marker-gated Python dependencies: ${names.join(", ")}. Environment-specific requirements are not resolved in file-based analysis.`,
-    );
-  }
-
-  return notes;
 }
 
 function parsePackageSpec(spec: string): {

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -6,6 +6,7 @@ import { buildReportForPackageSpec } from "../../core/analyzer.js";
 import { loadConfig } from "../../core/config/loader.js";
 import type { DependencyDiff } from "../../core/diff/types.js";
 import { parseLockfile } from "../../core/lockfile/parser.js";
+import { buildPythonManifestNotes } from "../../core/lockfile/python-notes.js";
 import {
   type ParsedPythonManifest,
   parsePyprojectManifest,
@@ -294,31 +295,10 @@ export function buildPythonReviewNotes(
   parsed: ParsedPythonManifest,
   includeDev: boolean | undefined,
 ): string[] {
-  const notes: string[] = [];
-
-  if (parsed.bestEffortDependencies.length > 0) {
-    notes.push(
-      `Best-effort resolution was used for: ${parsed.bestEffortDependencies.join(", ")}. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.`,
-    );
-  }
-
-  const markerSkipped = parsed.skipped.filter((entry) => entry.reason === "marker");
-  if (markerSkipped.length > 0) {
-    const names = markerSkipped
-      .map((entry) => entry.name ?? entry.spec)
-      .filter((value, index, all) => all.indexOf(value) === index);
-    notes.push(
-      `Skipped marker-gated Python dependencies: ${names.join(", ")}. Environment-specific requirements are not resolved in review mode.`,
-    );
-  }
-
-  if (includeDev && parsed.devDependencies.size > 0) {
-    notes.push(
-      `Included ${parsed.devDependencies.size} Python optional/dev dependencies in review mode.`,
-    );
-  }
-
-  return notes;
+  return buildPythonManifestNotes(parsed, {
+    includeDev,
+    mode: "review",
+  });
 }
 
 async function loadFileAtRefOrPath(filePath: string, ref?: string): Promise<string> {

--- a/src/core/lockfile/python-notes.ts
+++ b/src/core/lockfile/python-notes.ts
@@ -10,24 +10,31 @@ export function buildPythonManifestNotes(
   options: BuildPythonManifestNotesOptions,
 ): string[] {
   const notes: string[] = [];
+  const includeScopes: Set<"prod" | "dev"> = options.includeDev
+    ? new Set(["prod", "dev"])
+    : new Set(["prod"]);
+  const includedBestEffort = parsed.bestEffortDependencies.filter(
+    (name) =>
+      parsed.dependencies.has(name) || (options.includeDev && parsed.devDependencies.has(name)),
+  );
 
-  if (parsed.bestEffortDependencies.length > 0) {
+  if (includedBestEffort.length > 0) {
     notes.push(
-      `Best-effort Python resolution: ${formatList(parsed.bestEffortDependencies)}. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.`,
+      `Best-effort Python resolution: ${formatList(includedBestEffort)}. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.`,
     );
   }
 
-  const markerSkipped = summarizeSkipped(parsed.skipped, "marker");
+  const markerSkipped = summarizeSkipped(parsed.skipped, "marker", includeScopes);
   if (markerSkipped.length > 0) {
     notes.push(
       `Skipped marker-gated Python dependencies: ${formatList(markerSkipped)}. Environment-specific requirements are not evaluated.`,
     );
   }
 
-  const directiveSkipped = summarizeSkipped(parsed.skipped, "directive");
+  const directiveSkipped = summarizeSkipped(parsed.skipped, "directive", includeScopes);
   if (directiveSkipped.length > 0) {
     notes.push(
-      `Ignored requirements.txt directives: ${formatList(directiveSkipped)}. Only direct package specifiers are analyzed.`,
+      `Ignored requirements.txt directives: ${formatList(directiveSkipped)}; only direct package specifiers are analyzed.`,
     );
   }
 
@@ -43,11 +50,15 @@ export function buildPythonManifestNotes(
 function summarizeSkipped(
   skipped: SkippedPythonDependency[],
   reason: SkippedPythonDependency["reason"],
+  includeScopes: Set<"prod" | "dev">,
 ): string[] {
-  return skipped
-    .filter((entry) => entry.reason === reason)
-    .map((entry) => entry.name ?? entry.spec)
-    .filter((value, index, all) => all.indexOf(value) === index);
+  return [
+    ...new Set(
+      skipped
+        .filter((entry) => entry.reason === reason && includeScopes.has(entry.scope ?? "prod"))
+        .map((entry) => entry.name ?? entry.spec),
+    ),
+  ];
 }
 
 function formatList(values: string[]): string {

--- a/src/core/lockfile/python-notes.ts
+++ b/src/core/lockfile/python-notes.ts
@@ -1,0 +1,59 @@
+import type { ParsedPythonManifest, SkippedPythonDependency } from "./python-parser.js";
+
+interface BuildPythonManifestNotesOptions {
+  includeDev?: boolean;
+  mode: "analyze" | "review";
+}
+
+export function buildPythonManifestNotes(
+  parsed: ParsedPythonManifest,
+  options: BuildPythonManifestNotesOptions,
+): string[] {
+  const notes: string[] = [];
+
+  if (parsed.bestEffortDependencies.length > 0) {
+    notes.push(
+      `Best-effort Python resolution: ${formatList(parsed.bestEffortDependencies)}. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.`,
+    );
+  }
+
+  const markerSkipped = summarizeSkipped(parsed.skipped, "marker");
+  if (markerSkipped.length > 0) {
+    notes.push(
+      `Skipped marker-gated Python dependencies: ${formatList(markerSkipped)}. Environment-specific requirements are not evaluated.`,
+    );
+  }
+
+  const directiveSkipped = summarizeSkipped(parsed.skipped, "directive");
+  if (directiveSkipped.length > 0) {
+    notes.push(
+      `Ignored requirements.txt directives: ${formatList(directiveSkipped)}. Only direct package specifiers are analyzed.`,
+    );
+  }
+
+  if (options.mode === "review" && options.includeDev && parsed.devDependencies.size > 0) {
+    notes.push(
+      `Included ${parsed.devDependencies.size} Python optional/dev dependencies in review mode.`,
+    );
+  }
+
+  return notes;
+}
+
+function summarizeSkipped(
+  skipped: SkippedPythonDependency[],
+  reason: SkippedPythonDependency["reason"],
+): string[] {
+  return skipped
+    .filter((entry) => entry.reason === reason)
+    .map((entry) => entry.name ?? entry.spec)
+    .filter((value, index, all) => all.indexOf(value) === index);
+}
+
+function formatList(values: string[]): string {
+  if (values.length <= 3) {
+    return values.join(", ");
+  }
+
+  return `${values.slice(0, 3).join(", ")} (+${values.length - 3} more)`;
+}

--- a/src/core/lockfile/python-notes.ts
+++ b/src/core/lockfile/python-notes.ts
@@ -5,11 +5,51 @@ interface BuildPythonManifestNotesOptions {
   mode: "analyze" | "review";
 }
 
+export interface PythonDependencyNoteOptions {
+  bestEffortDependencies: string[];
+  markerSkipped: string[];
+  directiveSkipped: string[];
+  includedOptionalDevCount?: number;
+  reviewMode?: boolean;
+}
+
+export function buildPythonDependencyNotes(options: PythonDependencyNoteOptions): string[] {
+  const notes: string[] = [];
+  const bestEffortDependencies = uniqueValues(options.bestEffortDependencies);
+  const markerSkipped = uniqueValues(options.markerSkipped);
+  const directiveSkipped = uniqueValues(options.directiveSkipped);
+
+  if (bestEffortDependencies.length > 0) {
+    notes.push(
+      `Best-effort Python resolution: ${formatList(bestEffortDependencies)}. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.`,
+    );
+  }
+
+  if (markerSkipped.length > 0) {
+    notes.push(
+      `Skipped marker-gated Python dependencies: ${formatList(markerSkipped)}. Environment-specific requirements are not evaluated.`,
+    );
+  }
+
+  if (directiveSkipped.length > 0) {
+    notes.push(
+      `Ignored requirements.txt directives: ${formatList(directiveSkipped)}; only direct package specifiers are analyzed.`,
+    );
+  }
+
+  if ((options.includedOptionalDevCount ?? 0) > 0) {
+    notes.push(
+      `Included ${options.includedOptionalDevCount} Python optional/dev dependencies${options.reviewMode ? " in review mode" : ""}.`,
+    );
+  }
+
+  return notes;
+}
+
 export function buildPythonManifestNotes(
   parsed: ParsedPythonManifest,
   options: BuildPythonManifestNotesOptions,
 ): string[] {
-  const notes: string[] = [];
   const includeScopes: Set<"prod" | "dev"> = options.includeDev
     ? new Set(["prod", "dev"])
     : new Set(["prod"]);
@@ -17,34 +57,16 @@ export function buildPythonManifestNotes(
     (name) =>
       parsed.dependencies.has(name) || (options.includeDev && parsed.devDependencies.has(name)),
   );
-
-  if (includedBestEffort.length > 0) {
-    notes.push(
-      `Best-effort Python resolution: ${formatList(includedBestEffort)}. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.`,
-    );
-  }
-
   const markerSkipped = summarizeSkipped(parsed.skipped, "marker", includeScopes);
-  if (markerSkipped.length > 0) {
-    notes.push(
-      `Skipped marker-gated Python dependencies: ${formatList(markerSkipped)}. Environment-specific requirements are not evaluated.`,
-    );
-  }
-
   const directiveSkipped = summarizeSkipped(parsed.skipped, "directive", includeScopes);
-  if (directiveSkipped.length > 0) {
-    notes.push(
-      `Ignored requirements.txt directives: ${formatList(directiveSkipped)}; only direct package specifiers are analyzed.`,
-    );
-  }
-
-  if (options.mode === "review" && options.includeDev && parsed.devDependencies.size > 0) {
-    notes.push(
-      `Included ${parsed.devDependencies.size} Python optional/dev dependencies in review mode.`,
-    );
-  }
-
-  return notes;
+  return buildPythonDependencyNotes({
+    bestEffortDependencies: includedBestEffort,
+    markerSkipped,
+    directiveSkipped,
+    includedOptionalDevCount:
+      options.mode === "review" && options.includeDev ? parsed.devDependencies.size : 0,
+    reviewMode: options.mode === "review",
+  });
 }
 
 function summarizeSkipped(
@@ -59,6 +81,10 @@ function summarizeSkipped(
         .map((entry) => entry.name ?? entry.spec),
     ),
   ];
+}
+
+function uniqueValues(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 function formatList(values: string[]): string {

--- a/src/core/lockfile/python-parser.ts
+++ b/src/core/lockfile/python-parser.ts
@@ -6,6 +6,7 @@ export interface SkippedPythonDependency {
   name?: string;
   spec: string;
   reason: "directive" | "marker";
+  scope?: "prod" | "dev";
 }
 
 export interface ParsedPythonManifest {
@@ -36,15 +37,15 @@ export function parseRequirementsManifest(content: string): ParsedPythonManifest
     if (line === "" || line.startsWith("#")) continue;
 
     if (line.startsWith("-r ") || line.startsWith("-r\t")) {
-      skipped.push({ spec: line, reason: "directive" });
+      skipped.push({ spec: line, reason: "directive", scope: "prod" });
       continue;
     }
     if (line.startsWith("-e ") || line.startsWith("-e\t")) {
-      skipped.push({ spec: line, reason: "directive" });
+      skipped.push({ spec: line, reason: "directive", scope: "prod" });
       continue;
     }
     if (line.startsWith("--")) {
-      skipped.push({ spec: line, reason: "directive" });
+      skipped.push({ spec: line, reason: "directive", scope: "prod" });
       continue;
     }
 
@@ -52,7 +53,7 @@ export function parseRequirementsManifest(content: string): ParsedPythonManifest
     const cleaned = commentIdx !== -1 ? line.slice(0, commentIdx).trim() : line;
     if (cleaned === "") continue;
 
-    addParsedDep(cleaned, packages, skipped);
+    addParsedDep(cleaned, packages, skipped, "prod");
   }
 
   return {
@@ -103,7 +104,7 @@ export function parsePyprojectManifest(content: string): ParsedPythonManifest {
     readStringPath(parsedToml, ["tool", "poetry", "version"]);
 
   for (const dep of readStringArrayPath(parsedToml, ["project", "dependencies"])) {
-    addParsedDep(dep, dependencies, skipped);
+    addParsedDep(dep, dependencies, skipped, "prod");
   }
 
   for (const group of DEV_LIKE_GROUPS) {
@@ -112,13 +113,13 @@ export function parsePyprojectManifest(content: string): ParsedPythonManifest {
       "optional-dependencies",
       group,
     ])) {
-      addParsedDep(dep, devDependencies, skipped);
+      addParsedDep(dep, devDependencies, skipped, "dev");
     }
     for (const dep of readDependencyGroup(
       group,
       readTablePath(parsedToml, ["dependency-groups"]),
     )) {
-      addParsedDep(dep, devDependencies, skipped);
+      addParsedDep(dep, devDependencies, skipped, "dev");
     }
   }
 
@@ -126,17 +127,20 @@ export function parsePyprojectManifest(content: string): ParsedPythonManifest {
     readTablePath(parsedToml, ["tool", "poetry", "dependencies"]),
     dependencies,
     skipped,
+    "prod",
   );
   parsePoetryDependencySection(
     readTablePath(parsedToml, ["tool", "poetry", "dev-dependencies"]),
     devDependencies,
     skipped,
+    "dev",
   );
   for (const group of DEV_LIKE_GROUPS) {
     parsePoetryDependencySection(
       readTablePath(parsedToml, ["tool", "poetry", "group", group, "dependencies"]),
       devDependencies,
       skipped,
+      "dev",
     );
   }
 
@@ -159,13 +163,14 @@ function addParsedDep(
   dep: string,
   map: Map<string, string>,
   skipped: SkippedPythonDependency[],
+  scope: "prod" | "dev",
 ): void {
   const parsed = parsePep508(dep);
   if (!parsed) return;
 
   const { name, versionSpec, hasMarker } = parsed;
   if (hasMarker) {
-    skipped.push({ name, spec: dep, reason: "marker" });
+    skipped.push({ name, spec: dep, reason: "marker", scope });
     return;
   }
 
@@ -176,13 +181,14 @@ function parsePoetryDependencySection(
   section: TomlTable | undefined,
   map: Map<string, string>,
   skipped: SkippedPythonDependency[],
+  scope: "prod" | "dev",
 ): void {
   if (!section) return;
 
   for (const [name, value] of Object.entries(section)) {
     if (name.toLowerCase() === "python") continue;
 
-    const parsed = parsePoetryDependencyValue(name, value, skipped);
+    const parsed = parsePoetryDependencyValue(name, value, skipped, scope);
     if (parsed !== null) {
       map.set(name, normalizePythonVersionSpec(parsed));
     }
@@ -193,12 +199,18 @@ function parsePoetryDependencyValue(
   name: string,
   value: TomlValue,
   skipped: SkippedPythonDependency[],
+  scope: "prod" | "dev",
 ): string | null {
   if (typeof value === "string") return value;
 
   if (isTomlTable(value)) {
     if (hasPoetryMarker(value)) {
-      skipped.push({ name, spec: renderPoetryDependencySpec(name, value), reason: "marker" });
+      skipped.push({
+        name,
+        spec: renderPoetryDependencySpec(name, value),
+        reason: "marker",
+        scope,
+      });
       return null;
     }
 
@@ -207,12 +219,25 @@ function parsePoetryDependencyValue(
   }
 
   if (Array.isArray(value)) {
-    if (value.some((entry) => isTomlTable(entry) && hasPoetryMarker(entry))) {
-      skipped.push({ name, spec: renderPoetryDependencySpec(name, value), reason: "marker" });
+    const markerEntries = value.filter((entry) => isTomlTable(entry) && hasPoetryMarker(entry));
+    const nonMarkerEntries = value.filter(
+      (entry) => !isTomlTable(entry) || !hasPoetryMarker(entry),
+    );
+
+    if (markerEntries.length > 0) {
+      skipped.push({
+        name,
+        spec: renderPoetryDependencySpec(name, markerEntries),
+        reason: "marker",
+        scope,
+      });
+    }
+
+    if (nonMarkerEntries.length === 0) {
       return null;
     }
 
-    if (value.some((entry) => typeof entry === "string" || hasPoetryVersion(entry))) {
+    if (nonMarkerEntries.some((entry) => typeof entry === "string" || hasPoetryVersion(entry))) {
       return "";
     }
   }
@@ -220,11 +245,12 @@ function parsePoetryDependencyValue(
   return null;
 }
 
-function safeParseToml(content: string): TomlTable | undefined {
+function safeParseToml(content: string): TomlTable {
   try {
     return parseToml(content);
-  } catch {
-    return undefined;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse pyproject.toml: ${message}`);
   }
 }
 
@@ -315,7 +341,12 @@ function renderTomlValue(value: TomlValue): string {
 }
 
 function isTomlTable(value: TomlValue | undefined): value is TomlTable {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function collectBestEffortDependencies(packages: Map<string, string>): string[] {

--- a/src/core/lockfile/python-parser.ts
+++ b/src/core/lockfile/python-parser.ts
@@ -1,3 +1,5 @@
+import type { TomlTable, TomlValue } from "smol-toml";
+import { parse as parseToml } from "smol-toml";
 import { parsePep508 } from "../registry/pypi-client.js";
 
 export interface SkippedPythonDependency {
@@ -91,33 +93,48 @@ export function parsePyprojectManifest(content: string): ParsedPythonManifest {
   const dependencies = new Map<string, string>();
   const devDependencies = new Map<string, string>();
   const skipped: SkippedPythonDependency[] = [];
+  const parsedToml = safeParseToml(content);
 
   const name =
-    extractStringField(content, "project", "name") ??
-    extractStringField(content, "tool.poetry", "name");
+    readStringPath(parsedToml, ["project", "name"]) ??
+    readStringPath(parsedToml, ["tool", "poetry", "name"]);
   const version =
-    extractStringField(content, "project", "version") ??
-    extractStringField(content, "tool.poetry", "version");
+    readStringPath(parsedToml, ["project", "version"]) ??
+    readStringPath(parsedToml, ["tool", "poetry", "version"]);
 
-  for (const dep of extractTomlArray(content, "project", "dependencies")) {
+  for (const dep of readStringArrayPath(parsedToml, ["project", "dependencies"])) {
     addParsedDep(dep, dependencies, skipped);
   }
 
   for (const group of DEV_LIKE_GROUPS) {
-    for (const dep of extractTomlArray(content, "project.optional-dependencies", group)) {
+    for (const dep of readStringArrayPath(parsedToml, [
+      "project",
+      "optional-dependencies",
+      group,
+    ])) {
       addParsedDep(dep, devDependencies, skipped);
     }
-    for (const dep of extractTomlArray(content, "dependency-groups", group)) {
+    for (const dep of readDependencyGroup(
+      group,
+      readTablePath(parsedToml, ["dependency-groups"]),
+    )) {
       addParsedDep(dep, devDependencies, skipped);
     }
   }
 
-  parsePoetryDependencySection(content, "tool.poetry.dependencies", dependencies, skipped);
-  parsePoetryDependencySection(content, "tool.poetry.dev-dependencies", devDependencies, skipped);
+  parsePoetryDependencySection(
+    readTablePath(parsedToml, ["tool", "poetry", "dependencies"]),
+    dependencies,
+    skipped,
+  );
+  parsePoetryDependencySection(
+    readTablePath(parsedToml, ["tool", "poetry", "dev-dependencies"]),
+    devDependencies,
+    skipped,
+  );
   for (const group of DEV_LIKE_GROUPS) {
     parsePoetryDependencySection(
-      content,
-      `tool.poetry.group.${group}.dependencies`,
+      readTablePath(parsedToml, ["tool", "poetry", "group", group, "dependencies"]),
       devDependencies,
       skipped,
     );
@@ -156,108 +173,149 @@ function addParsedDep(
 }
 
 function parsePoetryDependencySection(
-  content: string,
-  section: string,
+  section: TomlTable | undefined,
   map: Map<string, string>,
   skipped: SkippedPythonDependency[],
 ): void {
-  const sectionContent = extractSectionContent(content, section);
-  if (!sectionContent) return;
+  if (!section) return;
 
-  for (const rawLine of sectionContent.split("\n")) {
-    const line = rawLine.trim();
-    if (line === "" || line.startsWith("#")) continue;
-
-    const simpleMatch = line.match(/^([A-Za-z0-9._-]+)\s*=\s*["']([^"']+)["']/);
-    if (simpleMatch) {
-      const name = simpleMatch[1];
-      if (name.toLowerCase() === "python") continue;
-      map.set(name, normalizePythonVersionSpec(simpleMatch[2]));
-      continue;
-    }
-
-    const inlineTableMatch = line.match(/^([A-Za-z0-9._-]+)\s*=\s*\{(.+)\}$/);
-    if (!inlineTableMatch) continue;
-
-    const name = inlineTableMatch[1];
+  for (const [name, value] of Object.entries(section)) {
     if (name.toLowerCase() === "python") continue;
 
-    const tableBody = inlineTableMatch[2];
-    const markerMatch = tableBody.match(/markers\s*=\s*["']([^"']+)["']/);
-    if (markerMatch) {
-      skipped.push({ name, spec: line, reason: "marker" });
+    const parsed = parsePoetryDependencyValue(name, value, skipped);
+    if (parsed !== null) {
+      map.set(name, normalizePythonVersionSpec(parsed));
+    }
+  }
+}
+
+function parsePoetryDependencyValue(
+  name: string,
+  value: TomlValue,
+  skipped: SkippedPythonDependency[],
+): string | null {
+  if (typeof value === "string") return value;
+
+  if (isTomlTable(value)) {
+    if (hasPoetryMarker(value)) {
+      skipped.push({ name, spec: renderPoetryDependencySpec(name, value), reason: "marker" });
+      return null;
+    }
+
+    const version = readStringPath(value, ["version"]);
+    return version ?? null;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.some((entry) => isTomlTable(entry) && hasPoetryMarker(entry))) {
+      skipped.push({ name, spec: renderPoetryDependencySpec(name, value), reason: "marker" });
+      return null;
+    }
+
+    if (value.some((entry) => typeof entry === "string" || hasPoetryVersion(entry))) {
+      return "";
+    }
+  }
+
+  return null;
+}
+
+function safeParseToml(content: string): TomlTable | undefined {
+  try {
+    return parseToml(content);
+  } catch {
+    return undefined;
+  }
+}
+
+function readDependencyGroup(
+  group: string,
+  dependencyGroups: TomlTable | undefined,
+  seen = new Set<string>(),
+): string[] {
+  if (!dependencyGroups || seen.has(group)) return [];
+
+  seen.add(group);
+
+  const value = dependencyGroups[group];
+  if (!Array.isArray(value)) return [];
+
+  const resolved: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      resolved.push(entry);
       continue;
     }
 
-    const versionMatch = tableBody.match(/version\s*=\s*["']([^"']+)["']/);
-    if (versionMatch) {
-      map.set(name, normalizePythonVersionSpec(versionMatch[1]));
+    if (!isTomlTable(entry)) continue;
+
+    const includedGroup = readStringPath(entry, ["include-group"]);
+    if (includedGroup) {
+      resolved.push(...readDependencyGroup(includedGroup, dependencyGroups, seen));
     }
   }
+
+  return resolved;
 }
 
-function extractSectionContent(content: string, section: string): string | null {
-  const sectionPattern = new RegExp(`^\\[${escapeRegex(section)}\\]\\s*$`, "m");
-  const sectionMatch = sectionPattern.exec(content);
-  if (!sectionMatch) return null;
-
-  const afterSection = content.slice(sectionMatch.index + sectionMatch[0].length);
-  const nextSectionMatch = afterSection.match(/^\[/m);
-  return nextSectionMatch ? afterSection.slice(0, nextSectionMatch.index) : afterSection;
-}
-
-/**
- * Extract a simple string field from a TOML section.
- */
-function extractStringField(content: string, section: string, field: string): string | null {
-  const sectionContent = extractSectionContent(content, section);
-  if (!sectionContent) return null;
-
-  const fieldPattern = new RegExp(`^${escapeRegex(field)}\\s*=\\s*["']([^"']*)["']`, "m");
-  const fieldMatch = fieldPattern.exec(sectionContent);
-  return fieldMatch ? fieldMatch[1] : null;
-}
-
-/**
- * Extract an array value from a TOML section.
- */
-function extractTomlArray(content: string, section: string, field: string): string[] {
-  const sectionContent = extractSectionContent(content, section);
-  if (!sectionContent) return [];
-
-  const fieldStart = new RegExp(`^${escapeRegex(field)}\\s*=\\s*\\[`, "m");
-  const fieldMatch = fieldStart.exec(sectionContent);
-  if (!fieldMatch) return [];
-
-  const bracketStart = fieldMatch.index + fieldMatch[0].length;
-  const remaining = sectionContent.slice(bracketStart);
-
-  let closingBracket = -1;
-  let inString = false;
-  let stringChar = "";
-  for (let i = 0; i < remaining.length; i++) {
-    const ch = remaining[i];
-    if (inString) {
-      if (ch === stringChar) inString = false;
-    } else if (ch === '"' || ch === "'") {
-      inString = true;
-      stringChar = ch;
-    } else if (ch === "]") {
-      closingBracket = i;
-      break;
-    }
-  }
-  if (closingBracket === -1) return [];
-
-  const arrayContent = remaining.slice(0, closingBracket);
-  const items: string[] = [];
-  const stringPattern = /["']([^"']*)["']/g;
-  for (const match of arrayContent.matchAll(stringPattern)) {
-    const value = match[1].trim();
-    if (value !== "") items.push(value);
+function readValuePath(root: TomlTable | undefined, path: string[]): TomlValue | undefined {
+  let current: TomlValue | undefined = root;
+  for (const segment of path) {
+    if (!isTomlTable(current)) return undefined;
+    current = current[segment];
   }
 
-  return items;
+  return current;
+}
+
+function readStringPath(root: TomlTable | undefined, path: string[]): string | undefined {
+  const value = readValuePath(root, path);
+  return typeof value === "string" ? value : undefined;
+}
+
+function readStringArrayPath(root: TomlTable | undefined, path: string[]): string[] {
+  const value = readValuePath(root, path);
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function readTablePath(root: TomlTable | undefined, path: string[]): TomlTable | undefined {
+  const value = readValuePath(root, path);
+  return isTomlTable(value) ? value : undefined;
+}
+
+function hasPoetryMarker(value: TomlTable): boolean {
+  return typeof value.markers === "string";
+}
+
+function hasPoetryVersion(value: TomlValue): boolean {
+  return isTomlTable(value) && typeof value.version === "string";
+}
+
+function renderPoetryDependencySpec(name: string, value: TomlValue): string {
+  return `${name} = ${renderTomlValue(value)}`;
+}
+
+function renderTomlValue(value: TomlValue): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => renderTomlValue(entry)).join(", ")}]`;
+  }
+  if (isTomlTable(value)) {
+    return `{ ${Object.entries(value)
+      .map(([key, entry]) => `${key} = ${renderTomlValue(entry)}`)
+      .join(", ")} }`;
+  }
+
+  return String(value);
+}
+
+function isTomlTable(value: TomlValue | undefined): value is TomlTable {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function collectBestEffortDependencies(packages: Map<string, string>): string[] {
@@ -277,8 +335,4 @@ function normalizePythonVersionSpec(versionSpec: string): string {
   const trimmed = versionSpec.trim();
   const pinnedMatch = trimmed.match(/^==\s*(.+)$/);
   return pinnedMatch ? pinnedMatch[1].trim() : trimmed;
-}
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/action/action.test.ts
+++ b/test/action/action.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+describe("composite action regression coverage", () => {
+  it("documents Python manifests and forwards Python review arguments", () => {
+    const action = YAML.parse(
+      readFileSync(join(import.meta.dirname, "../../action.yml"), "utf-8"),
+    ) as {
+      inputs: Record<string, { description?: string }>;
+      runs: {
+        steps: Array<{ name?: string; run?: string }>;
+      };
+    };
+
+    expect(action.inputs.path.description).toContain("requirements.txt");
+    expect(action.inputs.path.description).toContain("pyproject.toml");
+    expect(action.inputs["lockfile-path"].description).toContain("Python lockfiles");
+
+    const reviewStep = action.runs.steps.find((step) => step.name === "Run aminet review");
+    const forwardedPath = '"$' + '{{ inputs.path }}"';
+    const forwardedLockfile = 'ARGS+=("--lockfile-path" "$' + '{{ inputs.lockfile-path }}")';
+
+    expect(reviewStep?.run).toContain(forwardedPath);
+    expect(reviewStep?.run).toContain(forwardedLockfile);
+    expect(reviewStep?.run).toContain('ARGS+=("--no-dev")');
+  });
+});

--- a/test/action/action.test.ts
+++ b/test/action/action.test.ts
@@ -16,7 +16,9 @@ describe("composite action regression coverage", () => {
 
     expect(action.inputs.path.description).toContain("requirements.txt");
     expect(action.inputs.path.description).toContain("pyproject.toml");
-    expect(action.inputs["lockfile-path"].description).toContain("Python lockfiles");
+    expect(action.inputs["lockfile-path"].description).toContain("lockfile");
+    expect(action.inputs["lockfile-path"].description).toContain("pyproject.toml");
+    expect(action.inputs["lockfile-path"].description).toContain("uv.lock");
 
     const reviewStep = action.runs.steps.find((step) => step.name === "Run aminet review");
     const forwardedPath = '"$' + '{{ inputs.path }}"';

--- a/test/cli/commands/review.python-flow.test.ts
+++ b/test/cli/commands/review.python-flow.test.ts
@@ -1,0 +1,222 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { buildReportForPackageSpec } = vi.hoisted(() => ({
+  buildReportForPackageSpec: vi.fn(),
+}));
+
+const { loadConfig } = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+const { getDatabase } = vi.hoisted(() => ({
+  getDatabase: vi.fn(),
+}));
+
+const { fetchWithRetry } = vi.hoisted(() => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+vi.mock("../../../src/core/analyzer.js", () => ({
+  buildReportForPackageSpec,
+}));
+
+vi.mock("../../../src/core/config/loader.js", () => ({
+  loadConfig,
+}));
+
+vi.mock("../../../src/core/store/database.js", () => ({
+  getDatabase,
+}));
+
+vi.mock("../../../src/utils/http.js", () => ({
+  fetchWithRetry,
+}));
+
+import { loadAdjacentLockfile, reviewCommand } from "../../../src/cli/commands/review.js";
+
+describe("reviewCommand Python regression coverage", () => {
+  let tempRoot: string;
+  let previousCwd: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "aminet-review-python-"));
+    previousCwd = process.cwd();
+    process.chdir(tempRoot);
+    execFileSync("git", ["init"], { cwd: tempRoot });
+    execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: tempRoot });
+    execFileSync("git", ["config", "user.name", "Codex"], { cwd: tempRoot });
+
+    buildReportForPackageSpec.mockReset();
+    buildReportForPackageSpec.mockImplementation(async (name: string, spec: string) => ({
+      graph: { nodes: new Map(), edges: [], root: `${name}@${spec}` },
+      vulnerabilities: [],
+      report: {
+        root: `${name}@${spec}`,
+        totalPackages: 1,
+        directDependencies: 1,
+        maxDepth: 1,
+        entries: [
+          {
+            name,
+            version: spec,
+            id: `${name}@${spec}`,
+            depth: 0,
+            license: "MIT",
+            licenseCategory: "permissive",
+            vulnerabilities: [],
+          },
+        ],
+        summary: {
+          licenseCounts: {
+            permissive: 1,
+            copyleft: 0,
+            "weak-copyleft": 0,
+            unknown: 0,
+          },
+          vulnerabilityCount: 0,
+          criticalCount: 0,
+          highCount: 0,
+          mediumCount: 0,
+          lowCount: 0,
+        },
+      },
+    }));
+  });
+
+  afterEach(async () => {
+    process.chdir(previousCwd);
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("renders a Python review diff and markdown output from a temp git repo", async () => {
+    await writeText(
+      "services/api/pyproject.toml",
+      [
+        "[project]",
+        'name = "api"',
+        'version = "1.0.0"',
+        'dependencies = ["fastapi>=0.116"]',
+        "",
+      ].join("\n"),
+    );
+    await writeText(
+      "services/api/uv.lock",
+      ["[[package]]", 'name = "fastapi"', 'version = "0.116.0"', ""].join("\n"),
+    );
+    execFileSync("git", ["add", "."], { cwd: tempRoot });
+    execFileSync("git", ["commit", "-m", "base"], { cwd: tempRoot });
+
+    await writeText(
+      "services/api/pyproject.toml",
+      [
+        "[project]",
+        'name = "api"',
+        'version = "1.0.0"',
+        "dependencies = [",
+        '  "fastapi>=0.117",',
+        '  "httpx==0.28.1",',
+        '  "typing-extensions>=4.0; python_version < \\"3.11\\"",',
+        "]",
+        "",
+      ].join("\n"),
+    );
+    await writeText(
+      "services/api/uv.lock",
+      [
+        "[[package]]",
+        'name = "fastapi"',
+        'version = "0.117.1"',
+        "",
+        "[[package]]",
+        'name = "httpx"',
+        'version = "0.28.1"',
+        "",
+      ].join("\n"),
+    );
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await reviewCommand("services/api/pyproject.toml", {
+        base: "HEAD",
+        ci: true,
+        updateComment: false,
+      });
+      const output = logSpy.mock.calls.map((args) => args.map(String).join(" ")).join("\n");
+      expect(output).toContain("### New Dependencies");
+      expect(output).toContain("### Updated Dependencies");
+      expect(output).toContain("| httpx |");
+      expect(output).toContain("| fastapi |");
+      expect(output).toContain("Best-effort resolution was used for: fastapi.");
+      expect(output).toContain("Skipped marker-gated Python dependencies: typing-extensions.");
+      expect(buildReportForPackageSpec).toHaveBeenCalledWith(
+        "fastapi",
+        "0.117.1",
+        expect.objectContaining({ ecosystem: "pypi" }),
+      );
+      expect(buildReportForPackageSpec).toHaveBeenCalledWith(
+        "httpx",
+        "0.28.1",
+        expect.objectContaining({ ecosystem: "pypi" }),
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("keeps npm and Python lockfile discovery separated in a mixed repo", async () => {
+    await writeText(
+      "package.json",
+      JSON.stringify({ name: "root-app", version: "1.0.0", dependencies: { react: "^18.3.0" } }),
+    );
+    await writeText(
+      "pnpm-lock.yaml",
+      [
+        "lockfileVersion: '9.0'",
+        "importers:",
+        "  .:",
+        "    dependencies:",
+        "      react:",
+        "        version: 18.3.1",
+        "",
+      ].join("\n"),
+    );
+    await writeText(
+      "services/api/pyproject.toml",
+      [
+        "[project]",
+        'name = "api"',
+        'version = "1.0.0"',
+        'dependencies = ["fastapi>=0.116"]',
+        "",
+      ].join("\n"),
+    );
+    await writeText(
+      "services/api/uv.lock",
+      ["[[package]]", 'name = "fastapi"', 'version = "0.116.1"', ""].join("\n"),
+    );
+
+    const npmLockfile = await loadAdjacentLockfile("package.json");
+    const pythonLockfile = await loadAdjacentLockfile(
+      "services/api/pyproject.toml",
+      undefined,
+      undefined,
+      "pypi",
+    );
+
+    expect(npmLockfile?.format).toBe("pnpm-lock.yaml");
+    expect(npmLockfile?.packages.get("react")).toBe("18.3.1");
+    expect(pythonLockfile?.format).toBe("uv.lock");
+    expect(pythonLockfile?.packages.get("fastapi")).toBe("0.116.1");
+    expect(pythonLockfile?.packages.has("react")).toBe(false);
+  });
+});
+
+async function writeText(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}

--- a/test/cli/commands/review.python-flow.test.ts
+++ b/test/cli/commands/review.python-flow.test.ts
@@ -151,7 +151,7 @@ describe("reviewCommand Python regression coverage", () => {
       expect(output).toContain("### Updated Dependencies");
       expect(output).toContain("| httpx |");
       expect(output).toContain("| fastapi |");
-      expect(output).toContain("Best-effort resolution was used for: fastapi.");
+      expect(output).toContain("Best-effort Python resolution: fastapi.");
       expect(output).toContain("Skipped marker-gated Python dependencies: typing-extensions.");
       expect(buildReportForPackageSpec).toHaveBeenCalledWith(
         "fastapi",

--- a/test/cli/commands/review.test.ts
+++ b/test/cli/commands/review.test.ts
@@ -164,17 +164,20 @@ describe("python review manifest helpers", () => {
   it("builds review notes for requirements.txt manifests", () => {
     const parsed = parsePythonReviewManifest(
       "requirements.txt",
-      'requests==2.31.0\nfastapi>=0.116 ; python_version >= "3.10"\nurllib3\n',
+      '-r base.txt\nrequests==2.31.0\nfastapi>=0.116 ; python_version >= "3.10"\nurllib3\n',
       false,
     );
 
     expect(parsed.dependencies.get("requests")).toBe("2.31.0");
     expect(parsed.dependencies.get("urllib3")).toBe("");
     expect(parsed.notes).toContain(
-      "Best-effort resolution was used for: urllib3. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.",
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
     );
     expect(parsed.notes).toContain(
-      "Skipped marker-gated Python dependencies: fastapi. Environment-specific requirements are not resolved in review mode.",
+      "Skipped marker-gated Python dependencies: fastapi. Environment-specific requirements are not evaluated.",
+    );
+    expect(parsed.notes).toContain(
+      "Ignored requirements.txt directives: -r base.txt. Only direct package specifiers are analyzed.",
     );
   });
 
@@ -218,8 +221,8 @@ dev = ["pytest>=8.0"]
     );
 
     expect(notes).toEqual([
-      "Best-effort resolution was used for: urllib3. Unpinned Python specs are reviewed against the latest compatible PyPI release and may not match the exact environment.",
-      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not resolved in review mode.",
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
       "Included 1 Python optional/dev dependencies in review mode.",
     ]);
   });

--- a/test/cli/commands/review.test.ts
+++ b/test/cli/commands/review.test.ts
@@ -177,7 +177,7 @@ describe("python review manifest helpers", () => {
       "Skipped marker-gated Python dependencies: fastapi. Environment-specific requirements are not evaluated.",
     );
     expect(parsed.notes).toContain(
-      "Ignored requirements.txt directives: -r base.txt. Only direct package specifiers are analyzed.",
+      "Ignored requirements.txt directives: -r base.txt; only direct package specifiers are analyzed.",
     );
   });
 

--- a/test/cli/output/markdown.test.ts
+++ b/test/cli/output/markdown.test.ts
@@ -190,13 +190,13 @@ describe("renderMarkdownComment", () => {
   it("renders analysis notes when present", () => {
     const diff = makeEmptyDiff();
     diff.notes = [
-      "Best-effort resolution was used for: fastapi.",
+      "Best-effort Python resolution: fastapi.",
       "Skipped marker-gated Python dependencies: typing-extensions.",
     ];
 
     const md = renderMarkdownComment(diff);
     expect(md).toContain("### Analysis Notes");
-    expect(md).toContain("Best-effort resolution was used for: fastapi.");
+    expect(md).toContain("Best-effort Python resolution: fastapi.");
     expect(md).toContain("Skipped marker-gated Python dependencies: typing-extensions.");
   });
 

--- a/test/cli/output/table.test.ts
+++ b/test/cli/output/table.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderTable } from "../../../src/cli/output/table.js";
+
+describe("renderTable", () => {
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  afterEach(() => {
+    logSpy.mockClear();
+  });
+
+  it("renders analysis notes without rewriting their wording", () => {
+    renderTable({
+      root: "python-app@1.2.3",
+      totalPackages: 1,
+      directDependencies: 1,
+      maxDepth: 1,
+      entries: [],
+      analysisNotes: [
+        "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+        "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
+      ],
+      summary: {
+        licenseCounts: {
+          permissive: 0,
+          copyleft: 0,
+          "weak-copyleft": 0,
+          unknown: 0,
+        },
+        vulnerabilityCount: 0,
+        criticalCount: 0,
+        highCount: 0,
+        mediumCount: 0,
+        lowCount: 0,
+      },
+    });
+
+    const output = logSpy.mock.calls
+      .map((call) => call.map((value) => String(value)).join(" "))
+      .join("\n");
+
+    expect(output).toContain("Analysis Notes:");
+    expect(output).toContain(
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+    );
+    expect(output).toContain(
+      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
+    );
+  });
+});

--- a/test/core/lockfile/python-notes.test.ts
+++ b/test/core/lockfile/python-notes.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { buildPythonManifestNotes } from "../../../src/core/lockfile/python-notes.js";
+import {
+  buildPythonDependencyNotes,
+  buildPythonManifestNotes,
+} from "../../../src/core/lockfile/python-notes.js";
+
+describe("buildPythonDependencyNotes", () => {
+  it("deduplicates repeated note inputs and preserves shared wording", () => {
+    expect(
+      buildPythonDependencyNotes({
+        bestEffortDependencies: ["urllib3", "urllib3"],
+        markerSkipped: ["typing-extensions", "typing-extensions"],
+        directiveSkipped: ["-r base.txt", "-r base.txt"],
+        includedOptionalDevCount: 2,
+        reviewMode: true,
+      }),
+    ).toEqual([
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
+      "Ignored requirements.txt directives: -r base.txt; only direct package specifiers are analyzed.",
+      "Included 2 Python optional/dev dependencies in review mode.",
+    ]);
+  });
+});
 
 describe("buildPythonManifestNotes", () => {
   it("formats aligned analyze notes for best-effort, marker skips, and directives", () => {

--- a/test/core/lockfile/python-notes.test.ts
+++ b/test/core/lockfile/python-notes.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildPythonManifestNotes } from "../../../src/core/lockfile/python-notes.js";
+
+describe("buildPythonManifestNotes", () => {
+  it("formats aligned analyze notes for best-effort, marker skips, and directives", () => {
+    const notes = buildPythonManifestNotes(
+      {
+        name: "demo",
+        version: "1.0.0",
+        dependencies: new Map([["urllib3", ""]]),
+        devDependencies: new Map(),
+        skipped: [
+          {
+            name: "typing-extensions",
+            spec: 'typing-extensions; python_version < "3.11"',
+            reason: "marker",
+          },
+          { spec: "-r base.txt", reason: "directive" },
+          { spec: "-e .", reason: "directive" },
+        ],
+        bestEffortDependencies: ["urllib3"],
+      },
+      { mode: "analyze" },
+    );
+
+    expect(notes).toEqual([
+      "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+      "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
+      "Ignored requirements.txt directives: -r base.txt, -e .. Only direct package specifiers are analyzed.",
+    ]);
+  });
+
+  it("caps long note lists and keeps review-specific dev messaging last", () => {
+    const notes = buildPythonManifestNotes(
+      {
+        name: "demo",
+        version: "1.0.0",
+        dependencies: new Map(),
+        devDependencies: new Map([
+          ["pytest", ">=8.0"],
+          ["ruff", "0.12.0"],
+        ]),
+        skipped: [
+          { spec: "-r base.txt", reason: "directive" },
+          { spec: "-e .", reason: "directive" },
+          { spec: "--index-url https://example.invalid/simple", reason: "directive" },
+          { spec: "--extra-index-url https://example.invalid/extra", reason: "directive" },
+        ],
+        bestEffortDependencies: ["urllib3", "httpx", "fastapi", "pydantic"],
+      },
+      { includeDev: true, mode: "review" },
+    );
+
+    expect(notes).toEqual([
+      "Best-effort Python resolution: urllib3, httpx, fastapi (+1 more). Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
+      "Ignored requirements.txt directives: -r base.txt, -e ., --index-url https://example.invalid/simple (+1 more). Only direct package specifiers are analyzed.",
+      "Included 2 Python optional/dev dependencies in review mode.",
+    ]);
+  });
+});

--- a/test/core/lockfile/python-notes.test.ts
+++ b/test/core/lockfile/python-notes.test.ts
@@ -14,9 +14,10 @@ describe("buildPythonManifestNotes", () => {
             name: "typing-extensions",
             spec: 'typing-extensions; python_version < "3.11"',
             reason: "marker",
+            scope: "prod",
           },
-          { spec: "-r base.txt", reason: "directive" },
-          { spec: "-e .", reason: "directive" },
+          { spec: "-r base.txt", reason: "directive", scope: "prod" },
+          { spec: "-e .", reason: "directive", scope: "prod" },
         ],
         bestEffortDependencies: ["urllib3"],
       },
@@ -26,7 +27,7 @@ describe("buildPythonManifestNotes", () => {
     expect(notes).toEqual([
       "Best-effort Python resolution: urllib3. Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
       "Skipped marker-gated Python dependencies: typing-extensions. Environment-specific requirements are not evaluated.",
-      "Ignored requirements.txt directives: -r base.txt, -e .. Only direct package specifiers are analyzed.",
+      "Ignored requirements.txt directives: -r base.txt, -e .; only direct package specifiers are analyzed.",
     ]);
   });
 
@@ -37,14 +38,24 @@ describe("buildPythonManifestNotes", () => {
         version: "1.0.0",
         dependencies: new Map(),
         devDependencies: new Map([
-          ["pytest", ">=8.0"],
-          ["ruff", "0.12.0"],
+          ["urllib3", ""],
+          ["httpx", ""],
+          ["fastapi", ""],
+          ["pydantic", ""],
         ]),
         skipped: [
-          { spec: "-r base.txt", reason: "directive" },
-          { spec: "-e .", reason: "directive" },
-          { spec: "--index-url https://example.invalid/simple", reason: "directive" },
-          { spec: "--extra-index-url https://example.invalid/extra", reason: "directive" },
+          { spec: "-r base.txt", reason: "directive", scope: "prod" },
+          { spec: "-e .", reason: "directive", scope: "prod" },
+          {
+            spec: "--index-url https://example.invalid/simple",
+            reason: "directive",
+            scope: "prod",
+          },
+          {
+            spec: "--extra-index-url https://example.invalid/extra",
+            reason: "directive",
+            scope: "prod",
+          },
         ],
         bestEffortDependencies: ["urllib3", "httpx", "fastapi", "pydantic"],
       },
@@ -53,8 +64,39 @@ describe("buildPythonManifestNotes", () => {
 
     expect(notes).toEqual([
       "Best-effort Python resolution: urllib3, httpx, fastapi (+1 more). Unpinned direct specs use the latest compatible PyPI release as a stand-in and may not match the exact environment.",
-      "Ignored requirements.txt directives: -r base.txt, -e ., --index-url https://example.invalid/simple (+1 more). Only direct package specifiers are analyzed.",
-      "Included 2 Python optional/dev dependencies in review mode.",
+      "Ignored requirements.txt directives: -r base.txt, -e ., --index-url https://example.invalid/simple (+1 more); only direct package specifiers are analyzed.",
+      "Included 4 Python optional/dev dependencies in review mode.",
+    ]);
+  });
+
+  it("filters dev-only best-effort and marker notes when includeDev is disabled", () => {
+    const notes = buildPythonManifestNotes(
+      {
+        name: "demo",
+        version: "1.0.0",
+        dependencies: new Map([["requests", "2.31.0"]]),
+        devDependencies: new Map([["pytest", ""]]),
+        skipped: [
+          {
+            name: "typing-extensions",
+            spec: 'typing-extensions; python_version < "3.11"',
+            reason: "marker",
+            scope: "dev",
+          },
+          {
+            name: "httpx",
+            spec: 'httpx; python_version < "3.11"',
+            reason: "marker",
+            scope: "prod",
+          },
+        ],
+        bestEffortDependencies: ["pytest"],
+      },
+      { mode: "review" },
+    );
+
+    expect(notes).toEqual([
+      "Skipped marker-gated Python dependencies: httpx. Environment-specific requirements are not evaluated.",
     ]);
   });
 });

--- a/test/core/lockfile/python-parser.test.ts
+++ b/test/core/lockfile/python-parser.test.ts
@@ -173,6 +173,25 @@ docs = ["mkdocs==1.6.0"]
       expect(result.devDependencies.get("mkdocs")).toBe("1.6.0");
     });
 
+    it("follows include-group references inside dependency-groups", () => {
+      const result = parsePyprojectManifest(`
+[project]
+name = "dep-groups-include"
+version = "1.0.0"
+dependencies = ["requests>=2.31"]
+
+[dependency-groups]
+docs = ["mkdocs>=1.6.0", { include-group = "typing" }]
+typing = ["mypy>=1.11.0"]
+qa = ["bandit>=1.8.0"]
+`);
+
+      expect(result.dependencies.get("requests")).toBe(">=2.31");
+      expect(result.devDependencies.get("mkdocs")).toBe(">=1.6.0");
+      expect(result.devDependencies.get("mypy")).toBe(">=1.11.0");
+      expect(result.devDependencies.has("bandit")).toBe(false);
+    });
+
     it("parses Poetry dependencies and groups", () => {
       const result = parsePyprojectManifest(`
 [tool.poetry]
@@ -223,6 +242,28 @@ black = "25.1.0"
       expect(result.dependencies.get("fastapi")).toBe("^0.116.0");
       expect(result.devDependencies.get("pytest")).toBe("^8.4.0");
       expect(result.devDependencies.get("black")).toBe("25.1.0");
+    });
+
+    it("treats Poetry multi-constraint arrays as best-effort dependencies", () => {
+      const result = parsePyprojectManifest(`
+[tool.poetry]
+name = "poetry-constraints"
+version = "1.0.0"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+httpx = { version = "^0.28.1", extras = ["http2"] }
+pydantic = [
+  { version = "<2", python = "<3.12" },
+  { version = "^2.8", python = ">=3.12" },
+]
+internal-lib = { path = "../internal-lib", develop = true }
+`);
+
+      expect(result.dependencies.get("httpx")).toBe("^0.28.1");
+      expect(result.dependencies.get("pydantic")).toBe("");
+      expect(result.dependencies.has("internal-lib")).toBe(false);
+      expect(result.bestEffortDependencies).toContain("pydantic");
     });
 
     it("does not mark four-part pinned versions as best-effort", () => {

--- a/test/core/lockfile/python-parser.test.ts
+++ b/test/core/lockfile/python-parser.test.ts
@@ -63,7 +63,7 @@ requests==2.31.0
 
     it("tracks skipped directives and best-effort requirements", () => {
       const result = parseRequirementsManifest(`-r base.txt\nrequests\nurllib3>=2.0\n`);
-      expect(result.skipped).toEqual([{ spec: "-r base.txt", reason: "directive" }]);
+      expect(result.skipped).toEqual([{ spec: "-r base.txt", reason: "directive", scope: "prod" }]);
       expect(result.bestEffortDependencies).toEqual(["requests", "urllib3"]);
     });
   });
@@ -143,17 +143,15 @@ dependencies = [
       expect(result.dependencies.get("flask")).toBe("3.0.0");
     });
 
-    it("returns empty maps for malformed TOML instead of throwing", () => {
-      const result = parsePyprojectDependencies(`
+    it("throws for malformed TOML", () => {
+      expect(() =>
+        parsePyprojectDependencies(`
 [project
 name = "broken"
 dependencies = [
   "requests>=2.20",
-`);
-      expect(result.name).toBeUndefined();
-      expect(result.version).toBeUndefined();
-      expect(result.dependencies.size).toBe(0);
-      expect(result.devDependencies.size).toBe(0);
+`),
+      ).toThrow("Failed to parse pyproject.toml");
     });
 
     it("parses dependency-groups as dev dependencies", () => {
@@ -221,6 +219,7 @@ ruff = { version = "==0.12.0" }
           name: "typing-extensions",
           spec: 'typing-extensions = { version = "^4.15.0", markers = "python_version < \'3.11\'" }',
           reason: "marker",
+          scope: "prod",
         },
       ]);
     });
@@ -264,6 +263,45 @@ internal-lib = { path = "../internal-lib", develop = true }
       expect(result.dependencies.get("pydantic")).toBe("");
       expect(result.dependencies.has("internal-lib")).toBe(false);
       expect(result.bestEffortDependencies).toContain("pydantic");
+    });
+
+    it("keeps non-marker Poetry array constraints when only some entries have markers", () => {
+      const result = parsePyprojectManifest(`
+[tool.poetry]
+name = "poetry-mixed"
+version = "1.0.0"
+
+[tool.poetry.dependencies]
+demo-lib = [
+  { version = "<2", markers = "python_version < '3.12'" },
+  { version = "^2.8" },
+]
+`);
+
+      expect(result.dependencies.get("demo-lib")).toBe("");
+      expect(result.bestEffortDependencies).toContain("demo-lib");
+      expect(result.skipped).toEqual([
+        {
+          name: "demo-lib",
+          spec: 'demo-lib = [{ version = "<2", markers = "python_version < \'3.12\'" }]',
+          reason: "marker",
+          scope: "prod",
+        },
+      ]);
+    });
+
+    it("ignores TOML date values when checking for tables", () => {
+      const result = parsePyprojectManifest(`
+[project]
+name = "dated"
+version = "1.0.0"
+dependencies = ["requests>=2.31"]
+
+[tool.example]
+released = 2026-04-06T07:30:00Z
+`);
+
+      expect(result.dependencies.get("requests")).toBe(">=2.31");
     });
 
     it("does not mark four-part pinned versions as best-effort", () => {

--- a/test/fixtures/python/realistic-pyproject.toml
+++ b/test/fixtures/python/realistic-pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "realistic-app"
+version = "0.2.0"
+dependencies = [
+  "httpx>=0.27",
+  "sqlalchemy>=2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.3",
+  "coverage[toml]>=7.6",
+]
+lint = [
+  "ruff==0.12.0",
+]
+ci = [
+  "pre-commit>=4.0",
+]
+
+[dependency-groups]
+docs = [
+  "mkdocs-material>=9.5",
+  { include-group = "typing" },
+]
+typing = [
+  "mypy>=1.11",
+]
+qa = [
+  "bandit>=1.8",
+]
+
+[tool.ruff]
+line-length = 100

--- a/test/integration/python-pipeline.test.ts
+++ b/test/integration/python-pipeline.test.ts
@@ -156,6 +156,31 @@ describe("Python parsing: Black pyproject.toml (extras syntax)", () => {
   });
 });
 
+describe("Python parsing: realistic pyproject.toml (mixed sections)", () => {
+  const content = loadText("realistic-pyproject.toml");
+  const parsed = parsePyprojectDependencies(content);
+
+  it("extracts project metadata from the supported scopes", () => {
+    expect(parsed.name).toBe("realistic-app");
+    expect(parsed.version).toBe("0.2.0");
+  });
+
+  it("collects production dependencies despite unrelated sections", () => {
+    expect(parsed.dependencies.get("httpx")).toBe(">=0.27");
+    expect(parsed.dependencies.get("sqlalchemy")).toBe(">=2.0");
+  });
+
+  it("collects dev-like dependency groups, including include-group entries", () => {
+    expect(parsed.devDependencies.get("pytest")).toBe(">=8.3");
+    expect(parsed.devDependencies.get("coverage")).toBe(">=7.6");
+    expect(parsed.devDependencies.get("ruff")).toBe("0.12.0");
+    expect(parsed.devDependencies.get("mkdocs-material")).toBe(">=9.5");
+    expect(parsed.devDependencies.get("mypy")).toBe(">=1.11");
+    expect(parsed.devDependencies.has("pre-commit")).toBe(false);
+    expect(parsed.devDependencies.has("bandit")).toBe(false);
+  });
+});
+
 // ─── requirements.txt parsing tests against real OSS files ───────────
 
 describe("Python parsing: httpx requirements.txt", () => {


### PR DESCRIPTION
## Summary
- extract shared Python analysis-note builders for best-effort, skipped inputs, and optional dev dependencies
- make analyze and review use the same wording and note ordering for Python output semantics
- add regression coverage for the shared helper, review note rendering, and table output

## Testing
- pnpm install --frozen-lockfile
- pnpm exec vitest test/core/lockfile/python-notes.test.ts test/cli/commands/analyze.test.ts test/cli/commands/review.test.ts test/cli/output/table.test.ts --run
- pnpm build
- pnpm exec biome check src/cli/commands/analyze.ts src/cli/commands/review.ts src/core/lockfile/python-notes.ts test/cli/commands/review.test.ts test/core/lockfile/python-notes.test.ts test/cli/output/table.test.ts

## Issue
- Closes #42