### PR TITLE
fix: filter GHSA advisories by version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ Top-level commands:
 - `ci`: JSON-oriented CI alias for `analyze`
 - `review`: PR review mode for direct dependency changes
 - `init`: generate `aminet.config.json` interactively
+- `validate-config`: validate `aminet.config.json`
+- `ignore`: manage vulnerability ignore rules
 - `cache`: local cache inspection and pruning
 
 Use the built-in help for the complete option set:
@@ -308,6 +310,8 @@ Use the built-in help for the complete option set:
 ```bash
 npx aminet analyze --help
 npx aminet review --help
+npx aminet validate-config --help
+npx aminet ignore --help
 ```
 
 ## Configuration
@@ -320,6 +324,16 @@ Place an `aminet.config.json` in your project root to set defaults:
   "npmToken": "npm_...",
   "denyLicenses": ["GPL-3.0", "AGPL-3.0"],
   "allowLicenses": ["MIT", "ISC", "Apache-2.0"],
+  "vulnerabilityIgnores": [
+    {
+      "package": "serve",
+      "advisory": "GHSA-48gc-5j93-5cfq",
+      "source": "ghsa",
+      "versions": ">= 14.0.0",
+      "reason": "Not affected because the installed version is outside the vulnerable range.",
+      "expires": "2026-09-30"
+    }
+  ],
   "depth": 5,
   "concurrency": 5,
   "security": true,
@@ -328,6 +342,55 @@ Place an `aminet.config.json` in your project root to set defaults:
 ```
 
 All fields are optional. CLI flags and Action inputs override config file values. For `npmToken`, the resolution order is: CLI `--npm-token` > `NPM_TOKEN` environment variable > config file.
+
+### Vulnerability ignores
+
+Use `vulnerabilityIgnores` for reviewed false positives or temporary operational exceptions. Each rule removes only the matching advisory for the matching package; it does not skip the package or hide unrelated advisories.
+
+```json
+{
+  "vulnerabilityIgnores": [
+    {
+      "package": "path-to-regexp",
+      "advisory": "GHSA-9wv6-86v2-598j",
+      "source": "ghsa",
+      "versions": "3.3.0",
+      "reason": "The installed version is the first patched version.",
+      "expires": "2026-09-30"
+    }
+  ]
+}
+```
+
+Fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `package` | yes | Package name or wildcard pattern, such as `@scope/*`. |
+| `advisory` | yes | Advisory ID or alias, such as `GHSA-...`, `CVE-...`, or an OSV ID. |
+| `source` | no | Limit the rule to `osv`, `ghsa`, or `npm-audit`. Omit it to match any source. |
+| `versions` | no | SemVer range for installed versions where the ignore applies. Omit it only for package-wide advisory exceptions. |
+| `reason` | yes | Human-readable justification for the suppression. |
+| `expires` | recommended | Review date in `YYYY-MM-DD` format. Expired rules are not applied. |
+
+Validate config before relying on suppressions:
+
+```bash
+npx aminet validate-config
+npx aminet validate-config ./config/aminet.config.json
+```
+
+Add and inspect suppression rules from the CLI:
+
+```bash
+npx aminet ignore add serve GHSA-48gc-5j93-5cfq \
+  --source ghsa \
+  --versions ">= 14.0.0" \
+  --reason "Not affected because the installed version is outside the vulnerable range." \
+  --expires 2026-09-30
+
+npx aminet ignore list
+```
 
 ## What `aminet` does
 
@@ -340,6 +403,7 @@ All fields are optional. CLI flags and Action inputs override config file values
 ## Feature overview
 
 - Vulnerability scanning via OSV, GHSA, and npm audit
+- Advisory-level vulnerability suppressions with config validation
 - License categorization, deny-list checks, compatibility checks, and deep tarball license verification
 - Enhanced license intelligence via ClearlyDefined
 - Trust scoring from packument data, downloads, and deps.dev metadata

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -248,6 +248,7 @@ async function analyzeFile(
     dev: options.dev,
     noCache: options.noCache,
     excludePackages,
+    vulnerabilityIgnores: config.vulnerabilityIgnores,
   });
 
   if (spinner) {
@@ -408,6 +409,7 @@ async function analyzePythonFile(
       concurrency: options.concurrency,
       noCache: options.noCache,
       ecosystem: "pypi",
+      vulnerabilityIgnores: config.vulnerabilityIgnores,
     },
   );
 
@@ -476,7 +478,14 @@ async function analyzePackage(
   const vulnSources = parseVulnSources(options.vulnSources);
 
   const osvEcosystem = ecosystem === "pypi" ? "PyPI" : "npm";
-  const vulnerabilities = await scanPhase(graph, options, useSpinner, vulnSources, osvEcosystem);
+  const vulnerabilities = await scanPhase(
+    graph,
+    options,
+    useSpinner,
+    vulnSources,
+    osvEcosystem,
+    config.vulnerabilityIgnores,
+  );
 
   outputAndExit(graph, vulnerabilities, options, config);
 }
@@ -501,6 +510,7 @@ async function scanPhase(
   useSpinner: boolean,
   vulnSources?: VulnSource[],
   ecosystem = "npm",
+  vulnerabilityIgnores?: AmiConfig["vulnerabilityIgnores"],
 ): Promise<VulnerabilityResult[]> {
   const spinner = useSpinner ? ora("Scanning for vulnerabilities...").start() : null;
 
@@ -516,6 +526,7 @@ async function scanPhase(
       !options.noCache,
       vulnSources,
       ecosystem,
+      vulnerabilityIgnores,
     );
     const totalVulns = vulnerabilities.reduce((sum, v) => sum + v.vulnerabilities.length, 0);
     if (totalVulns > 0) {

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -1,0 +1,125 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import chalk from "chalk";
+import type { AmiConfig, VulnerabilityIgnoreRule } from "../../core/config/types.js";
+import { type ConfigValidationIssue, validateConfig } from "../../core/config/validator.js";
+
+const DEFAULT_CONFIG_PATH = "aminet.config.json";
+
+export interface IgnoreAddOptions {
+  config?: string;
+  source?: string;
+  versions?: string;
+  reason?: string;
+  expires?: string;
+}
+
+export interface IgnoreListOptions {
+  config?: string;
+}
+
+export function ignoreAddCommand(
+  packageName: string,
+  advisory: string,
+  options: IgnoreAddOptions,
+): void {
+  const configPath = resolve(options.config ?? DEFAULT_CONFIG_PATH);
+  const config = readConfigOrEmpty(configPath);
+
+  if (config.vulnerabilityIgnores !== undefined && !Array.isArray(config.vulnerabilityIgnores)) {
+    console.error(chalk.red("vulnerabilityIgnores must be an array before adding a rule."));
+    process.exit(1);
+  }
+
+  const rule: VulnerabilityIgnoreRule = {
+    package: packageName,
+    advisory,
+    ...(options.source ? { source: options.source as VulnerabilityIgnoreRule["source"] } : {}),
+    ...(options.versions ? { versions: options.versions } : {}),
+    ...(options.reason ? { reason: options.reason } : {}),
+    ...(options.expires ? { expires: options.expires } : {}),
+  };
+
+  const rules = config.vulnerabilityIgnores ?? [];
+  if (rules.some((existing) => isSameRule(existing, rule))) {
+    console.error(chalk.yellow("A matching vulnerability ignore rule already exists."));
+    process.exit(1);
+  }
+
+  const nextConfig: AmiConfig = {
+    ...config,
+    vulnerabilityIgnores: [...rules, rule],
+  };
+
+  const issues = validateConfig(nextConfig);
+  printValidationIssues(issues);
+  if (issues.some((issue) => issue.severity === "error")) {
+    process.exit(1);
+  }
+
+  writeFileSync(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf-8");
+  console.log(chalk.green(`Added vulnerability ignore to ${configPath}`));
+}
+
+export function ignoreListCommand(options: IgnoreListOptions): void {
+  const configPath = resolve(options.config ?? DEFAULT_CONFIG_PATH);
+  if (!existsSync(configPath)) {
+    console.log("No vulnerability ignores configured.");
+    return;
+  }
+
+  const config = readConfigOrEmpty(configPath);
+  const rules = Array.isArray(config.vulnerabilityIgnores) ? config.vulnerabilityIgnores : [];
+  if (rules.length === 0) {
+    console.log("No vulnerability ignores configured.");
+    return;
+  }
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    const parts = [
+      `${i + 1}. ${rule.package} ${rule.advisory}`,
+      rule.source ? `source=${rule.source}` : null,
+      rule.versions ? `versions=${rule.versions}` : null,
+      rule.expires ? `expires=${rule.expires}` : null,
+    ].filter((part): part is string => Boolean(part));
+    console.log(parts.join(" | "));
+    if (rule.reason) {
+      console.log(`   reason: ${rule.reason}`);
+    }
+  }
+}
+
+function readConfigOrEmpty(configPath: string): AmiConfig {
+  if (!existsSync(configPath)) {
+    return {};
+  }
+  try {
+    return JSON.parse(readFileSync(configPath, "utf-8")) as AmiConfig;
+  } catch (error) {
+    console.error(
+      chalk.red(`Failed to parse ${configPath}: ${error instanceof Error ? error.message : error}`),
+    );
+    process.exit(1);
+  }
+}
+
+function printValidationIssues(issues: ConfigValidationIssue[]): void {
+  for (const issue of issues) {
+    const message = `${issue.severity} ${issue.path}: ${issue.message}`;
+    if (issue.severity === "error") {
+      console.error(chalk.red(message));
+    } else {
+      console.error(chalk.yellow(message));
+    }
+  }
+}
+
+function isSameRule(a: VulnerabilityIgnoreRule, b: VulnerabilityIgnoreRule): boolean {
+  return (
+    a.package === b.package &&
+    a.advisory === b.advisory &&
+    a.source === b.source &&
+    a.versions === b.versions
+  );
+}

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -119,6 +119,7 @@ export async function reviewCommand(target: string, options: ReviewOptions): Pro
     noCache: options.noCache,
     security: options.security,
     ecosystem,
+    vulnerabilityIgnores: config.vulnerabilityIgnores,
   };
 
   const baseLockfile = await loadAdjacentLockfile(target, baseRef, options.lockfilePath, ecosystem);

--- a/src/cli/commands/validate-config.ts
+++ b/src/cli/commands/validate-config.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import chalk from "chalk";
+import { validateConfig } from "../../core/config/validator.js";
+
+export function validateConfigCommand(configPath = "aminet.config.json"): void {
+  const resolvedPath = resolve(configPath);
+  if (!existsSync(resolvedPath)) {
+    console.error(chalk.red(`Config file not found: ${resolvedPath}`));
+    process.exit(1);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(resolvedPath, "utf-8"));
+  } catch (error) {
+    console.error(
+      chalk.red(
+        `Failed to parse ${resolvedPath}: ${error instanceof Error ? error.message : error}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const issues = validateConfig(parsed);
+  const errors = issues.filter((issue) => issue.severity === "error");
+  const warnings = issues.filter((issue) => issue.severity === "warning");
+
+  for (const issue of errors) {
+    console.error(chalk.red(`error ${issue.path}: ${issue.message}`));
+  }
+  for (const issue of warnings) {
+    console.error(chalk.yellow(`warning ${issue.path}: ${issue.message}`));
+  }
+
+  if (errors.length > 0) {
+    process.exit(1);
+  }
+
+  console.log(chalk.green(`Config is valid: ${resolvedPath}`));
+}

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -1,6 +1,7 @@
 import { isExcludedPackage } from "../utils/exclude.js";
 import { logger } from "../utils/logger.js";
 import { runAnalysisPhases } from "./analysis/phases.js";
+import type { VulnerabilityIgnoreRule } from "./config/types.js";
 import { resolvePythonDependencyGraph } from "./graph/py-resolver.js";
 import { resolveDependencyGraph } from "./graph/resolver.js";
 import type { DependencyEdge, DependencyGraph, PackageNode } from "./graph/types.js";
@@ -23,6 +24,7 @@ export interface AnalyzerOptions {
   minTrustScore?: number;
   deepLicenseCheck?: boolean;
   excludePackages?: string[];
+  vulnerabilityIgnores?: VulnerabilityIgnoreRule[];
   ecosystem?: "npm" | "pypi";
 }
 
@@ -57,6 +59,7 @@ export async function buildReportForPackageSpec(
     !options.noCache,
     undefined,
     osvEcosystem,
+    options.vulnerabilityIgnores,
   ).catch(() => [] as VulnerabilityResult[]);
 
   const { reportOptions } = await runAnalysisPhases(graph, options).catch(() => ({
@@ -156,6 +159,7 @@ export async function buildReportFromPackageJson(
     !options.noCache,
     undefined,
     osvEcosystem,
+    options.vulnerabilityIgnores,
   ).catch(() => [] as VulnerabilityResult[]);
 
   const { reportOptions } = await runAnalysisPhases(graph, options).catch(() => ({

--- a/src/core/config/types.ts
+++ b/src/core/config/types.ts
@@ -1,7 +1,19 @@
+import type { VulnSource } from "../vulnerability/aggregator.js";
+
+export interface VulnerabilityIgnoreRule {
+  package: string;
+  advisory: string;
+  source?: VulnSource;
+  versions?: string;
+  reason?: string;
+  expires?: string;
+}
+
 export interface AmiConfig {
   denyLicenses?: string[];
   allowLicenses?: string[]; // whitelist: anything not listed triggers a warning
   licenseOverrides?: Record<string, string>; // "pkg@version": "SPDX-ID"
+  vulnerabilityIgnores?: VulnerabilityIgnoreRule[];
   failOnVuln?: string;
   failOnLicense?: string;
   depth?: number;

--- a/src/core/config/validator.ts
+++ b/src/core/config/validator.ts
@@ -1,0 +1,235 @@
+import semver from "semver";
+import type { AmiConfig } from "./types.js";
+
+export interface ConfigValidationIssue {
+  severity: "error" | "warning";
+  path: string;
+  message: string;
+}
+
+const VULN_SOURCES = new Set(["osv", "ghsa", "npm-audit"]);
+const VULN_THRESHOLDS = new Set(["low", "medium", "high", "critical"]);
+const LICENSE_THRESHOLDS = new Set(["copyleft", "weak-copyleft"]);
+
+export function validateConfig(config: unknown, now = new Date()): ConfigValidationIssue[] {
+  const issues: ConfigValidationIssue[] = [];
+
+  if (!isObject(config)) {
+    return [
+      {
+        severity: "error",
+        path: "$",
+        message: "Config must be a JSON object.",
+      },
+    ];
+  }
+
+  validateStringArray(config, "denyLicenses", issues);
+  validateStringArray(config, "allowLicenses", issues);
+  validateStringArray(config, "excludePackages", issues);
+  validateStringRecord(config, "licenseOverrides", issues);
+  validateOptionalString(config, "npmToken", issues);
+  validateOptionalBoolean(config, "security", issues);
+  validateOptionalBoolean(config, "deepLicenseCheck", issues);
+  validateOptionalPositiveInteger(config, "depth", issues);
+  validateOptionalPositiveInteger(config, "concurrency", issues);
+  validateOptionalEnum(config, "failOnVuln", VULN_THRESHOLDS, issues);
+  validateOptionalEnum(config, "failOnLicense", LICENSE_THRESHOLDS, issues);
+  validateVulnerabilityIgnores(config as AmiConfig, issues, now);
+
+  return issues;
+}
+
+function validateVulnerabilityIgnores(
+  config: AmiConfig,
+  issues: ConfigValidationIssue[],
+  now: Date,
+): void {
+  if (config.vulnerabilityIgnores === undefined) {
+    return;
+  }
+  if (!Array.isArray(config.vulnerabilityIgnores)) {
+    issues.push({
+      severity: "error",
+      path: "$.vulnerabilityIgnores",
+      message: "vulnerabilityIgnores must be an array.",
+    });
+    return;
+  }
+
+  for (let i = 0; i < config.vulnerabilityIgnores.length; i++) {
+    const path = `$.vulnerabilityIgnores[${i}]`;
+    const rule = config.vulnerabilityIgnores[i] as unknown;
+    if (!isObject(rule)) {
+      issues.push({ severity: "error", path, message: "Ignore rule must be an object." });
+      continue;
+    }
+
+    requireNonEmptyString(rule, "package", `${path}.package`, issues);
+    requireNonEmptyString(rule, "advisory", `${path}.advisory`, issues);
+    requireNonEmptyString(rule, "reason", `${path}.reason`, issues);
+    validateOptionalEnum(rule, "source", VULN_SOURCES, issues, path);
+    validateOptionalString(rule, "versions", issues, path);
+    validateOptionalString(rule, "expires", issues, path);
+
+    if (typeof rule.versions === "string" && semver.validRange(rule.versions) === null) {
+      issues.push({
+        severity: "error",
+        path: `${path}.versions`,
+        message: "versions must be a valid semver range.",
+      });
+    }
+
+    if (typeof rule.expires === "string") {
+      const expiresAt = parseDateOnly(rule.expires);
+      if (!expiresAt) {
+        issues.push({
+          severity: "error",
+          path: `${path}.expires`,
+          message: "expires must use YYYY-MM-DD format.",
+        });
+      } else if (expiresAt.getTime() < startOfUtcDay(now).getTime()) {
+        issues.push({
+          severity: "error",
+          path: `${path}.expires`,
+          message: "expires is in the past.",
+        });
+      }
+    } else {
+      issues.push({
+        severity: "warning",
+        path: `${path}.expires`,
+        message: "Add an expires date so suppressions are reviewed periodically.",
+      });
+    }
+  }
+}
+
+function validateStringArray(
+  config: Record<string, unknown>,
+  key: keyof AmiConfig,
+  issues: ConfigValidationIssue[],
+): void {
+  const value = config[key];
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    issues.push({
+      severity: "error",
+      path: `$.${key}`,
+      message: `${key} must be an array of strings.`,
+    });
+  }
+}
+
+function validateStringRecord(
+  config: Record<string, unknown>,
+  key: keyof AmiConfig,
+  issues: ConfigValidationIssue[],
+): void {
+  const value = config[key];
+  if (value === undefined) return;
+  if (!isObject(value) || Object.values(value).some((item) => typeof item !== "string")) {
+    issues.push({
+      severity: "error",
+      path: `$.${key}`,
+      message: `${key} must be an object with string values.`,
+    });
+  }
+}
+
+function validateOptionalBoolean(
+  config: Record<string, unknown>,
+  key: keyof AmiConfig,
+  issues: ConfigValidationIssue[],
+): void {
+  const value = config[key];
+  if (value !== undefined && typeof value !== "boolean") {
+    issues.push({
+      severity: "error",
+      path: `$.${key}`,
+      message: `${key} must be a boolean.`,
+    });
+  }
+}
+
+function validateOptionalPositiveInteger(
+  config: Record<string, unknown>,
+  key: keyof AmiConfig,
+  issues: ConfigValidationIssue[],
+): void {
+  const value = config[key];
+  if (value === undefined) return;
+  if (!Number.isInteger(value) || Number(value) <= 0) {
+    issues.push({
+      severity: "error",
+      path: `$.${key}`,
+      message: `${key} must be a positive integer.`,
+    });
+  }
+}
+
+function validateOptionalString(
+  config: Record<string, unknown>,
+  key: string,
+  issues: ConfigValidationIssue[],
+  basePath = "$",
+): void {
+  const value = config[key];
+  if (value !== undefined && typeof value !== "string") {
+    issues.push({
+      severity: "error",
+      path: `${basePath}.${key}`,
+      message: `${key} must be a string.`,
+    });
+  }
+}
+
+function validateOptionalEnum(
+  config: Record<string, unknown>,
+  key: string,
+  allowed: ReadonlySet<string>,
+  issues: ConfigValidationIssue[],
+  basePath = "$",
+): void {
+  const value = config[key];
+  if (value === undefined) return;
+  if (typeof value !== "string" || !allowed.has(value)) {
+    issues.push({
+      severity: "error",
+      path: `${basePath}.${key}`,
+      message: `${key} must be one of: ${[...allowed].join(", ")}.`,
+    });
+  }
+}
+
+function requireNonEmptyString(
+  config: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ConfigValidationIssue[],
+): void {
+  const value = config[key];
+  if (typeof value !== "string" || value.trim() === "") {
+    issues.push({
+      severity: "error",
+      path,
+      message: `${key} is required and must be a non-empty string.`,
+    });
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseDateOnly(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}

--- a/src/core/vulnerability/aggregator.ts
+++ b/src/core/vulnerability/aggregator.ts
@@ -1,3 +1,5 @@
+import semver from "semver";
+
 import { logger } from "../../utils/logger.js";
 import type { NormalizedAdvisory } from "./advisory-types.js";
 import { queryGhsaAdvisories } from "./ghsa-client.js";
@@ -149,9 +151,14 @@ async function fetchNpmAudit(
  */
 function isVersionInRange(version: string, range: string): boolean {
   try {
-    const semver = require("semver");
     // GHSA uses comma-separated constraints: ">= 1.0.0, < 2.0.0"
-    const constraints = range.split(",").map((s) => s.trim());
+    const constraints = range
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (constraints.length === 0) {
+      return true;
+    }
     return constraints.every((constraint) => semver.satisfies(version, constraint));
   } catch {
     // If we can't parse, conservatively include

--- a/src/core/vulnerability/scanner.ts
+++ b/src/core/vulnerability/scanner.ts
@@ -1,5 +1,6 @@
 import { mapConcurrent } from "../../utils/concurrency.js";
 import { logger } from "../../utils/logger.js";
+import type { VulnerabilityIgnoreRule } from "../config/types.js";
 import type { DependencyGraph } from "../graph/types.js";
 import {
   cacheVulnerabilities,
@@ -9,6 +10,7 @@ import {
 import type { NormalizedAdvisory } from "./advisory-types.js";
 import { aggregateVulnerabilities, type VulnSource } from "./aggregator.js";
 import { queryBatchChunked, queryVulnDetails } from "./osv-client.js";
+import { applyVulnerabilityIgnores } from "./suppressions.js";
 import type { VulnerabilityResult } from "./types.js";
 
 export interface ScanOptions {
@@ -31,6 +33,7 @@ export async function scanVulnerabilities(
   useCache = true,
   sources?: VulnSource[],
   ecosystem = "npm",
+  vulnerabilityIgnores?: VulnerabilityIgnoreRule[],
 ): Promise<VulnerabilityResult[]> {
   const allPackages = Array.from(graph.nodes.values()).map((node) => ({
     name: node.name,
@@ -73,7 +76,7 @@ export async function scanVulnerabilities(
   }
 
   if (uncached.length === 0) {
-    return cachedResults;
+    return applyVulnerabilityIgnores(cachedResults, vulnerabilityIgnores).results;
   }
 
   logger.debug(`Scanning ${uncached.length} packages for vulnerabilities...`);
@@ -111,7 +114,7 @@ export async function scanVulnerabilities(
 
   if (vulnerablePackages.length === 0 && !useMultiSource) {
     logger.debug("No new vulnerabilities found.");
-    return cachedResults;
+    return applyVulnerabilityIgnores(cachedResults, vulnerabilityIgnores).results;
   }
 
   // Phase 2: Fetch details only for vulnerable packages (OSV)
@@ -144,7 +147,8 @@ export async function scanVulnerabilities(
     const activeSources = filterSourcesForEcosystem(sources ?? ["osv"], ecosystem);
     if (activeSources.length === 0) {
       logger.debug(`No compatible additional vulnerability sources for ecosystem ${ecosystem}`);
-      return [...cachedResults, ...freshResults];
+      return applyVulnerabilityIgnores([...cachedResults, ...freshResults], vulnerabilityIgnores)
+        .results;
     }
     logger.debug(`Fetching from additional sources: ${activeSources.join(", ")}`);
 
@@ -166,7 +170,8 @@ export async function scanVulnerabilities(
     }
   }
 
-  return [...cachedResults, ...freshResults];
+  return applyVulnerabilityIgnores([...cachedResults, ...freshResults], vulnerabilityIgnores)
+    .results;
 }
 
 function mergeAdvisories(

--- a/src/core/vulnerability/suppressions.ts
+++ b/src/core/vulnerability/suppressions.ts
@@ -1,0 +1,117 @@
+import semver from "semver";
+import { isExcludedPackage } from "../../utils/exclude.js";
+import { logger } from "../../utils/logger.js";
+import type { VulnerabilityIgnoreRule } from "../config/types.js";
+import type { NormalizedAdvisory } from "./advisory-types.js";
+import type { OsvVulnerability, VulnerabilityResult } from "./types.js";
+
+export interface SuppressionResult {
+  results: VulnerabilityResult[];
+  ignoredCount: number;
+}
+
+export function applyVulnerabilityIgnores(
+  results: VulnerabilityResult[],
+  rules: VulnerabilityIgnoreRule[] | undefined,
+  now = new Date(),
+): SuppressionResult {
+  const activeRules = (rules ?? []).filter((rule) => isRuleActive(rule, now));
+  if (activeRules.length === 0 || results.length === 0) {
+    return { results, ignoredCount: 0 };
+  }
+
+  let ignoredCount = 0;
+  const filteredResults: VulnerabilityResult[] = [];
+
+  for (const result of results) {
+    const matchingRules = activeRules.filter((rule) => matchesPackage(rule, result));
+    if (matchingRules.length === 0) {
+      filteredResults.push(result);
+      continue;
+    }
+
+    const vulnerabilities = result.vulnerabilities.filter((vulnerability) => {
+      const ignored = matchingRules.some((rule) => matchesOsvVulnerability(rule, vulnerability));
+      if (ignored) ignoredCount++;
+      return !ignored;
+    });
+
+    const advisories = result.advisories?.filter((advisory) => {
+      const ignored = matchingRules.some((rule) => matchesNormalizedAdvisory(rule, advisory));
+      if (ignored) ignoredCount++;
+      return !ignored;
+    });
+
+    if (vulnerabilities.length > 0 || (advisories && advisories.length > 0)) {
+      filteredResults.push({
+        ...result,
+        vulnerabilities,
+        advisories,
+      });
+    }
+  }
+
+  if (ignoredCount > 0) {
+    logger.info(`Ignored ${ignoredCount} vulnerability finding(s) from vulnerabilityIgnores`);
+  }
+
+  return { results: filteredResults, ignoredCount };
+}
+
+function isRuleActive(rule: VulnerabilityIgnoreRule, now: Date): boolean {
+  if (!rule.expires) return true;
+  const expiresAt = parseDateOnly(rule.expires);
+  if (!expiresAt) return false;
+  return expiresAt.getTime() >= startOfUtcDay(now).getTime();
+}
+
+function matchesPackage(rule: VulnerabilityIgnoreRule, result: VulnerabilityResult): boolean {
+  if (!isExcludedPackage(result.name, [rule.package])) {
+    return false;
+  }
+  if (!rule.versions) {
+    return true;
+  }
+  try {
+    return semver.satisfies(result.version, rule.versions, { includePrerelease: true });
+  } catch {
+    return false;
+  }
+}
+
+function matchesOsvVulnerability(
+  rule: VulnerabilityIgnoreRule,
+  vulnerability: OsvVulnerability,
+): boolean {
+  if (rule.source && rule.source !== "osv") {
+    return false;
+  }
+  return matchesAdvisoryId(rule.advisory, [vulnerability.id, ...(vulnerability.aliases ?? [])]);
+}
+
+function matchesNormalizedAdvisory(
+  rule: VulnerabilityIgnoreRule,
+  advisory: NormalizedAdvisory,
+): boolean {
+  if (rule.source && !advisory.sources.includes(rule.source)) {
+    return false;
+  }
+  return matchesAdvisoryId(rule.advisory, [advisory.id, ...advisory.aliases]);
+}
+
+function matchesAdvisoryId(expected: string, candidates: string[]): boolean {
+  const normalizedExpected = expected.trim().toLowerCase();
+  return candidates.some((candidate) => candidate.trim().toLowerCase() === normalizedExpected);
+}
+
+function parseDateOnly(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,10 @@
 import { Command } from "commander";
 import { analyzeCommand } from "./cli/commands/analyze.js";
 import { cacheClearCommand, cachePruneCommand, cacheStatsCommand } from "./cli/commands/cache.js";
+import { ignoreAddCommand, ignoreListCommand } from "./cli/commands/ignore.js";
 import { initCommand } from "./cli/commands/init.js";
 import { reviewCommand } from "./cli/commands/review.js";
+import { validateConfigCommand } from "./cli/commands/validate-config.js";
 import { AMINET_VERSION } from "./version.js";
 
 const program = new Command();
@@ -128,6 +130,34 @@ program
   .option("--force", "Overwrite existing config (use with --defaults)")
   .option("--merge", "Merge with existing config (use with --defaults)")
   .action(initCommand);
+
+// config validation command
+program
+  .command("validate-config")
+  .description("Validate aminet.config.json")
+  .argument("[path]", "Config file path", "aminet.config.json")
+  .action(validateConfigCommand);
+
+// vulnerability ignore commands
+const ignore = program.command("ignore").description("Manage vulnerability ignore rules");
+
+ignore
+  .command("add")
+  .description("Add a vulnerability ignore rule to aminet.config.json")
+  .argument("<package>", "Package name or wildcard pattern")
+  .argument("<advisory>", "Advisory ID or alias")
+  .option("--config <path>", "Config file path", "aminet.config.json")
+  .option("--source <source>", "Limit to a vulnerability source (osv, ghsa, npm-audit)")
+  .option("--versions <range>", "SemVer range where the ignore applies")
+  .requiredOption("--reason <text>", "Justification for the ignore rule")
+  .option("--expires <date>", "Review date in YYYY-MM-DD format")
+  .action(ignoreAddCommand);
+
+ignore
+  .command("list")
+  .description("List vulnerability ignore rules from aminet.config.json")
+  .option("--config <path>", "Config file path", "aminet.config.json")
+  .action(ignoreListCommand);
 
 // cache commands
 const cache = program.command("cache").description("Manage the local cache");

--- a/test/cli/commands/analyze.test.ts
+++ b/test/cli/commands/analyze.test.ts
@@ -130,6 +130,8 @@ describe("analyzeCommand Python lockfile support", () => {
 
   beforeEach(async () => {
     tempRoot = await mkdtemp(join(tmpdir(), "aminet-analyze-"));
+    loadConfig.mockReset();
+    loadConfig.mockReturnValue({});
     getDatabase.mockReset();
     buildReportFromPackageJson.mockReset();
     runAnalysisPhases.mockReset();
@@ -218,5 +220,45 @@ describe("analyzeCommand Python lockfile support", () => {
       exitSpy.mockRestore();
       stderrSpy.mockRestore();
     }
+  });
+
+  it("passes vulnerability ignore rules from config to file analysis", async () => {
+    const packageJsonPath = join(tempRoot, "package.json");
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: {
+          serve: "14.2.6",
+        },
+      }),
+    );
+    loadConfig.mockReturnValueOnce({
+      vulnerabilityIgnores: [
+        {
+          package: "serve",
+          advisory: "GHSA-48gc-5j93-5cfq",
+          reason: "Not affected in this version.",
+          expires: "2099-01-01",
+        },
+      ],
+    });
+
+    await analyzeCommand(packageJsonPath, { ci: true, json: true });
+
+    expect(buildReportFromPackageJson).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        vulnerabilityIgnores: [
+          {
+            package: "serve",
+            advisory: "GHSA-48gc-5j93-5cfq",
+            reason: "Not affected in this version.",
+            expires: "2099-01-01",
+          },
+        ],
+      }),
+    );
   });
 });

--- a/test/cli/commands/ignore.test.ts
+++ b/test/cli/commands/ignore.test.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ignoreAddCommand, ignoreListCommand } from "../../../src/cli/commands/ignore.js";
+
+describe("ignore commands", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "aminet-ignore-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  test("adds a vulnerability ignore rule to a config file", async () => {
+    const configPath = join(tempRoot, "aminet.config.json");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    ignoreAddCommand("serve", "GHSA-48gc-5j93-5cfq", {
+      config: configPath,
+      source: "ghsa",
+      versions: ">= 14.0.0",
+      reason: "Not affected in fixed serve releases.",
+      expires: "2099-01-01",
+    });
+
+    const config = JSON.parse(await readFile(configPath, "utf-8"));
+    expect(config.vulnerabilityIgnores).toEqual([
+      {
+        package: "serve",
+        advisory: "GHSA-48gc-5j93-5cfq",
+        source: "ghsa",
+        versions: ">= 14.0.0",
+        reason: "Not affected in fixed serve releases.",
+        expires: "2099-01-01",
+      },
+    ]);
+    expect(logSpy.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
+      "Added vulnerability ignore",
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not add duplicate vulnerability ignore rules", async () => {
+    const configPath = join(tempRoot, "aminet.config.json");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    ignoreAddCommand("serve", "GHSA-48gc-5j93-5cfq", {
+      config: configPath,
+      reason: "Initial suppression.",
+      expires: "2099-01-01",
+    });
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Added vulnerability ignore"));
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(async () =>
+      ignoreAddCommand("serve", "GHSA-48gc-5j93-5cfq", {
+        config: configPath,
+        reason: "Duplicate suppression.",
+        expires: "2099-01-01",
+      }),
+    ).rejects.toThrow("process.exit:1");
+
+    expect(errorSpy.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
+      "already exists",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("lists configured vulnerability ignore rules", async () => {
+    const configPath = join(tempRoot, "nested", "aminet.config.json");
+    await mkdir(join(tempRoot, "nested"), { recursive: true });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    ignoreAddCommand("path-to-regexp", "GHSA-9wv6-86v2-598j", {
+      config: configPath,
+      versions: "3.3.0",
+      reason: "First patched version.",
+      expires: "2099-01-01",
+    });
+    logSpy.mockClear();
+
+    ignoreListCommand({ config: configPath });
+
+    const output = logSpy.mock.calls.map(([value]) => String(value)).join("\n");
+    expect(output).toContain("path-to-regexp GHSA-9wv6-86v2-598j");
+    expect(output).toContain("versions=3.3.0");
+    expect(output).toContain("reason: First patched version.");
+  });
+});

--- a/test/cli/commands/validate-config.test.ts
+++ b/test/cli/commands/validate-config.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { validateConfigCommand } from "../../../src/cli/commands/validate-config.js";
+
+describe("validateConfigCommand", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "aminet-validate-config-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  test("prints success for a valid config", async () => {
+    const configPath = join(tempRoot, "aminet.config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        vulnerabilityIgnores: [
+          {
+            package: "serve",
+            advisory: "GHSA-48gc-5j93-5cfq",
+            reason: "Not affected in fixed serve releases.",
+            expires: "2099-01-01",
+          },
+        ],
+      }),
+    );
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    validateConfigCommand(configPath);
+
+    expect(logSpy.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
+      "Config is valid:",
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test("exits non-zero for an invalid config", async () => {
+    const configPath = join(tempRoot, "aminet.config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        vulnerabilityIgnores: [{ package: "serve", advisory: "", reason: "" }],
+      }),
+    );
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(async () => validateConfigCommand(configPath)).rejects.toThrow("process.exit:1");
+    expect(errorSpy.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
+      "$.vulnerabilityIgnores[0].advisory",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/core/config/loader.test.ts
+++ b/test/core/config/loader.test.ts
@@ -46,6 +46,14 @@ describe("loadConfig", () => {
       denyLicenses: ["GPL-3.0", "AGPL-3.0"],
       allowLicenses: ["MIT", "ISC"],
       licenseOverrides: { "pkg@1.0.0": "MIT" },
+      vulnerabilityIgnores: [
+        {
+          package: "serve",
+          advisory: "GHSA-48gc-5j93-5cfq",
+          reason: "Not affected in this version.",
+          expires: "2099-01-01",
+        },
+      ],
       failOnVuln: "high",
       failOnLicense: "copyleft",
       depth: 10,
@@ -58,6 +66,14 @@ describe("loadConfig", () => {
     expect(config.denyLicenses).toEqual(["GPL-3.0", "AGPL-3.0"]);
     expect(config.allowLicenses).toEqual(["MIT", "ISC"]);
     expect(config.licenseOverrides).toEqual({ "pkg@1.0.0": "MIT" });
+    expect(config.vulnerabilityIgnores).toEqual([
+      {
+        package: "serve",
+        advisory: "GHSA-48gc-5j93-5cfq",
+        reason: "Not affected in this version.",
+        expires: "2099-01-01",
+      },
+    ]);
     expect(config.failOnVuln).toBe("high");
     expect(config.failOnLicense).toBe("copyleft");
     expect(config.deepLicenseCheck).toBe(true);

--- a/test/core/config/validator.test.ts
+++ b/test/core/config/validator.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { validateConfig } from "../../../src/core/config/validator.js";
+
+describe("validateConfig", () => {
+  test("accepts a valid vulnerability ignore rule", () => {
+    const issues = validateConfig(
+      {
+        vulnerabilityIgnores: [
+          {
+            package: "serve",
+            advisory: "GHSA-48gc-5j93-5cfq",
+            source: "ghsa",
+            versions: ">= 14.0.0",
+            reason: "Not affected in fixed serve releases.",
+            expires: "2099-01-01",
+          },
+        ],
+      },
+      new Date("2026-06-17T00:00:00Z"),
+    );
+
+    expect(issues).toEqual([]);
+  });
+
+  test("reports invalid vulnerability ignore rules", () => {
+    const issues = validateConfig(
+      {
+        failOnVuln: "urgent",
+        vulnerabilityIgnores: [
+          {
+            package: "",
+            advisory: "GHSA-48gc-5j93-5cfq",
+            source: "github",
+            versions: "not a range",
+            reason: "",
+            expires: "2024-01-01",
+          },
+        ],
+      },
+      new Date("2026-06-17T00:00:00Z"),
+    );
+
+    expect(issues.filter((issue) => issue.severity === "error").map((issue) => issue.path)).toEqual(
+      [
+        "$.failOnVuln",
+        "$.vulnerabilityIgnores[0].package",
+        "$.vulnerabilityIgnores[0].reason",
+        "$.vulnerabilityIgnores[0].source",
+        "$.vulnerabilityIgnores[0].versions",
+        "$.vulnerabilityIgnores[0].expires",
+      ],
+    );
+  });
+
+  test("warns when a vulnerability ignore has no expiry", () => {
+    const issues = validateConfig({
+      vulnerabilityIgnores: [
+        {
+          package: "path-to-regexp",
+          advisory: "GHSA-9wv6-86v2-598j",
+          reason: "Temporary operational suppression.",
+        },
+      ],
+    });
+
+    expect(issues).toEqual([
+      {
+        severity: "warning",
+        path: "$.vulnerabilityIgnores[0].expires",
+        message: "Add an expires date so suppressions are reviewed periodically.",
+      },
+    ]);
+  });
+});

--- a/test/core/vulnerability/aggregator.test.ts
+++ b/test/core/vulnerability/aggregator.test.ts
@@ -88,6 +88,76 @@ describe("vulnerability aggregator", () => {
     expect(result.has("demo@2.5.0")).toBe(false);
   });
 
+  test("does not report fixed serve and path-to-regexp versions for historical GHSA ranges", async () => {
+    vi.doMock("../../../src/core/vulnerability/osv-client.js", () => ({
+      queryVulnDetails: async () => [],
+    }));
+    vi.doMock("../../../src/core/vulnerability/npm-audit-client.js", () => ({
+      queryNpmAudit: async () => new Map(),
+    }));
+
+    const advisory = (
+      id: string,
+      name: string,
+      vulnerableVersionRange: string,
+      firstPatchedVersion: string,
+    ) => ({
+      ghsa_id: id,
+      cve_id: null,
+      summary: `${name} advisory ${id}`,
+      description: "",
+      severity: "high",
+      cvss: { score: 7.5 },
+      type: "reviewed",
+      identifiers: [{ type: "GHSA", value: id }],
+      references: [],
+      published_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      vulnerabilities: [
+        {
+          package: { ecosystem: "npm", name },
+          vulnerable_version_range: vulnerableVersionRange,
+          first_patched_version: firstPatchedVersion,
+        },
+      ],
+    });
+
+    vi.doMock("../../../src/core/vulnerability/ghsa-client.js", () => ({
+      queryGhsaAdvisories: async (name: string) => {
+        if (name === "serve") {
+          return [
+            advisory("GHSA-48gc-5j93-5cfq", "serve", "< 10.1.2", "10.1.2"),
+            advisory("GHSA-v588-qcp3-jv46", "serve", "< 7.0.0", "7.0.0"),
+            advisory("GHSA-wm7q-rxch-43mx", "serve", "< 6.5.2", "6.5.2"),
+            advisory("GHSA-xg75-3277-gvvj", "serve", "< 7.1.3", "7.1.3"),
+            advisory("GHSA-xw79-hhv6-578c", "serve", "< 10.0.2", "10.0.2"),
+          ];
+        }
+
+        if (name === "path-to-regexp") {
+          return [advisory("GHSA-9wv6-86v2-598j", "path-to-regexp", "< 3.3.0", "3.3.0")];
+        }
+
+        return [];
+      },
+    }));
+
+    const { aggregateVulnerabilities } = await import(
+      "../../../src/core/vulnerability/aggregator.js"
+    );
+
+    const result = await aggregateVulnerabilities(
+      [
+        { name: "serve", version: "14.2.6" },
+        { name: "path-to-regexp", version: "3.3.0" },
+      ],
+      { sources: ["ghsa"] },
+    );
+
+    expect(result.has("serve@14.2.6")).toBe(false);
+    expect(result.has("path-to-regexp@3.3.0")).toBe(false);
+  });
+
   test("passes the ecosystem through to OSV detail lookups", async () => {
     const queryVulnDetails = vi.fn(async () => []);
 

--- a/test/core/vulnerability/suppressions.test.ts
+++ b/test/core/vulnerability/suppressions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+import { applyVulnerabilityIgnores } from "../../../src/core/vulnerability/suppressions.js";
+import type { VulnerabilityResult } from "../../../src/core/vulnerability/types.js";
+
+describe("applyVulnerabilityIgnores", () => {
+  test("suppresses matching OSV vulnerabilities by package, advisory, and version", () => {
+    const results: VulnerabilityResult[] = [
+      {
+        packageId: "serve@14.2.6",
+        name: "serve",
+        version: "14.2.6",
+        vulnerabilities: [
+          {
+            id: "OSV-2024-1",
+            aliases: ["GHSA-48gc-5j93-5cfq"],
+          },
+        ] as any,
+      },
+    ];
+
+    const filtered = applyVulnerabilityIgnores(results, [
+      {
+        package: "serve",
+        advisory: "GHSA-48gc-5j93-5cfq",
+        source: "osv",
+        versions: ">= 14.0.0",
+        reason: "Not affected in fixed serve releases.",
+        expires: "2099-01-01",
+      },
+    ]);
+
+    expect(filtered.ignoredCount).toBe(1);
+    expect(filtered.results).toEqual([]);
+  });
+
+  test("suppresses matching normalized advisories without removing unrelated findings", () => {
+    const results: VulnerabilityResult[] = [
+      {
+        packageId: "path-to-regexp@3.3.0",
+        name: "path-to-regexp",
+        version: "3.3.0",
+        vulnerabilities: [],
+        advisories: [
+          {
+            id: "GHSA-9wv6-86v2-598j",
+            aliases: [],
+            title: "Historical advisory",
+            description: "",
+            severity: "high",
+            cvssScore: 7.5,
+            sources: ["ghsa"],
+            isMalware: false,
+            fixedVersion: "3.3.0",
+            references: [],
+            publishedAt: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "GHSA-real",
+            aliases: [],
+            title: "Current advisory",
+            description: "",
+            severity: "critical",
+            cvssScore: 9.1,
+            sources: ["ghsa"],
+            isMalware: false,
+            fixedVersion: null,
+            references: [],
+            publishedAt: "2024-01-01T00:00:00Z",
+          },
+        ],
+      },
+    ];
+
+    const filtered = applyVulnerabilityIgnores(results, [
+      {
+        package: "path-to-regexp",
+        advisory: "GHSA-9wv6-86v2-598j",
+        source: "ghsa",
+        versions: "3.3.0",
+        reason: "Fixed at 3.3.0.",
+        expires: "2099-01-01",
+      },
+    ]);
+
+    expect(filtered.ignoredCount).toBe(1);
+    expect(filtered.results).toHaveLength(1);
+    expect(filtered.results[0].advisories?.map((advisory) => advisory.id)).toEqual(["GHSA-real"]);
+  });
+
+  test("does not apply expired or version-mismatched rules", () => {
+    const results: VulnerabilityResult[] = [
+      {
+        packageId: "serve@14.2.6",
+        name: "serve",
+        version: "14.2.6",
+        vulnerabilities: [{ id: "GHSA-48gc-5j93-5cfq", aliases: [] }] as any,
+      },
+    ];
+
+    const filtered = applyVulnerabilityIgnores(
+      results,
+      [
+        {
+          package: "serve",
+          advisory: "GHSA-48gc-5j93-5cfq",
+          source: "osv",
+          versions: "< 10.1.2",
+          reason: "Wrong version range.",
+          expires: "2099-01-01",
+        },
+        {
+          package: "serve",
+          advisory: "GHSA-48gc-5j93-5cfq",
+          source: "osv",
+          reason: "Expired suppression.",
+          expires: "2024-01-01",
+        },
+      ],
+      new Date("2026-06-17T00:00:00Z"),
+    );
+
+    expect(filtered.ignoredCount).toBe(0);
+    expect(filtered.results).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the ESM-unsafe dynamic `require("semver")` with a static semver import in GHSA range filtering.
- Add `vulnerabilityIgnores` config rules to suppress reviewed advisory-level false positives by package, advisory, source, and installed-version range.
- Add `aminet ignore add/list` and `aminet validate-config`, plus README documentation for safe suppression workflows.
- Add regression coverage for `serve@14.2.6`, `path-to-regexp@3.3.0`, suppression filtering, config validation, and ignore commands.

## Testing
- `pnpm test test/core/vulnerability/aggregator.test.ts`
- `pnpm test test/cli/commands/ignore.test.ts test/cli/commands/validate-config.test.ts test/core/config/validator.test.ts test/core/vulnerability/suppressions.test.ts test/core/config/loader.test.ts test/cli/commands/analyze.test.ts`
- `pnpm build`
- `pnpm lint`
- `pnpm test`

## Issue
- Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vulnerability suppression rules allowing users to ignore specific security advisories in their configuration with package/advisory matching, optional version constraints, and expiration dates
  * Added `aminet validate-config` command to validate configuration files
  * Added `aminet ignore add` and `aminet ignore list` commands to manage vulnerability suppressions

* **Documentation**
  * Updated README with new CLI commands and configuration examples for vulnerability suppressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->